### PR TITLE
doc/examples: remove 'ninja' as explicit dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GameMode depends on `meson` for building and `systemd` for internal communicatio
 # Ubuntu
 apt install meson libsystemd-dev pkg-config ninja-build
 # Arch
-pacman -S meson systemd ninja
+pacman -S meson systemd
 
 git clone https://github.com/FeralInteractive/gamemode.git
 cd gamemode

--- a/example/archlinux/gamemode-git/PKGBUILD
+++ b/example/archlinux/gamemode-git/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url="https://github.com/FeralInteractive/gamemode.git"
 license=('MIT')
 depends=('systemd' 'polkit')
-makedepends=('meson' 'ninja' 'pkg-config')
+makedepends=('meson' 'pkg-config')
 provides=('gamemode')
 source=("git+https://github.com/FeralInteractive/gamemode.git")
 sha256sums=('SKIP')
@@ -19,7 +19,7 @@ pkgver() {
 
 build() {
   cd gamemode
-  meson --prefix=/usr build -Dwithsystemd-user-unit-dir=/etc/systemd/user
+  arch-meson build
   cd build
   ninja
 }


### PR DESCRIPTION
as it's already required by meson.

Also use the default unit file path (/usr/lib/systemd/user/) for packaged versions. /etc/systemd/user is intended for manually installed services.

arch-meson is just a Meson wrapper with correct arch packaging prefixes set.