### PR TITLE
Ensure to set `_GNU_SOURCE` for POSIX compliance with signals

### DIFF
--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -29,6 +29,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
  */
 
+#define _GNU_SOURCE
+
 #include "dbus_messaging.h"
 #include "daemonize.h"
 #include "gamemode.h"

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -28,6 +28,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
  */
+
+#define _GNU_SOURCE
+
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
The systemd bus headers aren't setting a POSIX compliance level so we
define the catch-all to ensure the build doesn't error out, as seen with
issue #3. This is due to the reliance of `siginfo_t`, which requires a
minimum POSIX level of `199309L` when using glibc.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>