### PR TITLE
Prevent running bootstrap.sh as root

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 # Simple bootstrap script to build and run the daemon
+
+if [ "$EUID" -eq 0 ]
+  then echo "Please don't run bootstrap.sh as root."
+  exit
+fi
+
 set -e
 
 # Echo the rest so it's obvious


### PR DESCRIPTION
This pull request prevents users from running the script as root. This will prevent issue #12 from happening.