### PR TITLE
Integrated sd_notify to get status messages in systemd

### DIFF
--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -145,7 +145,7 @@ void game_mode_context_loop(GameModeContext *context)
 	}
 
 	LOG_MSG("Successfully initialised bus with name [%s]...\n", "com.feralinteractive.GameMode");
-	sd_notifyf(0,"STATUS=%sGameMode is ready to be activated.\n", "\x1B[1;36m");
+	sd_notifyf(0,"STATUS=%sGameMode is ready to be activated.%s\n", "\x1B[1;36m", "\x1B[0m");
 
 	/* Now loop, waiting for callbacks */
 	for (;;) {

--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -40,6 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 
 #include <systemd/sd-bus.h>
+#include <systemd/sd-daemon.h>
 
 /* systemd dbus components */
 static sd_bus *bus = NULL;
@@ -144,6 +145,7 @@ void game_mode_context_loop(GameModeContext *context)
 	}
 
 	LOG_MSG("Successfully initialised bus with name [%s]...\n", "com.feralinteractive.GameMode");
+	sd_notifyf(0,"STATUS=%sGameMode is ready to be activated.\n", "\x1B[1;36m");
 
 	/* Now loop, waiting for callbacks */
 	for (;;) {

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -162,7 +162,7 @@ void game_mode_context_destroy(GameModeContext *self)
 static void game_mode_context_enter(GameModeContext *self)
 {
 	LOG_MSG("Entering Game Mode...\n");
-	sd_notifyf(0,"STATUS=%sGameMode is now active.\n", "\x1B[1;32m");
+	sd_notifyf(0,"STATUS=%sGameMode is now active.%s\n", "\x1B[1;32m", "\x1B[0m");
 
 	if (!self->performance_mode && set_governors("performance")) {
 		self->performance_mode = true;
@@ -178,7 +178,7 @@ static void game_mode_context_enter(GameModeContext *self)
 static void game_mode_context_leave(GameModeContext *self)
 {
 	LOG_MSG("Leaving Game Mode...\n");
-	sd_notifyf(0,"STATUS=%sGameMode is currently deactivated.\n", "\x1B[1;36m");
+	sd_notifyf(0,"STATUS=%sGameMode is currently deactivated.%s\n", "\x1B[1;36m", "\x1B[0m");
 	
 	if (self->performance_mode && set_governors(NULL)) {
 		self->performance_mode = false;

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "governors.h"
 #include "logging.h"
 
+#include <systemd/sd-daemon.h>
 #include <linux/limits.h>
 #include <pthread.h>
 #include <signal.h>
@@ -161,6 +162,8 @@ void game_mode_context_destroy(GameModeContext *self)
 static void game_mode_context_enter(GameModeContext *self)
 {
 	LOG_MSG("Entering Game Mode...\n");
+	sd_notifyf(0,"STATUS=%sGameMode is now active.\n", "\x1B[1;32m");
+
 	if (!self->performance_mode && set_governors("performance")) {
 		self->performance_mode = true;
 	}
@@ -175,6 +178,8 @@ static void game_mode_context_enter(GameModeContext *self)
 static void game_mode_context_leave(GameModeContext *self)
 {
 	LOG_MSG("Leaving Game Mode...\n");
+	sd_notifyf(0,"STATUS=%sGameMode is currently deactivated.\n", "\x1B[1;36m");
+	
 	if (self->performance_mode && set_governors(NULL)) {
 		self->performance_mode = false;
 	}

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -55,6 +55,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "gamemode.h"
 #include "logging.h"
 
+#include <systemd/sd-daemon.h>
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
@@ -74,6 +75,7 @@ POSSIBILITY OF SUCH DAMAGE.
 static void sigint_handler(__attribute__((unused)) int signo)
 {
 	LOG_MSG("Quitting by request...\n");
+	sd_notify(0,"STATUS=GameMode is quitting by request...\n");
 
 	/* Clean up nicely */
 	game_mode_context_destroy(game_mode_context_instance());
@@ -141,4 +143,5 @@ int main(int argc, char *argv[])
 
 	/* Log we're finished */
 	LOG_MSG("Quitting naturally...\n");
+	sd_notify(0,"STATUS=GameMode is quitting naturally...\n");
 }

--- a/data/gamemoded.service.in
+++ b/data/gamemoded.service.in
@@ -4,6 +4,7 @@ Description=gamemoded
 [Service]
 Type=dbus
 BusName=com.feralinteractive.GameMode
+NotifyAccess=main
 ExecStart=@BINDIR@/gamemoded -l
 
 [Install]


### PR DESCRIPTION
Hi, 

i thought it would be cool to have status messages in systemctl's status output wether GameMode is currently active or not. systemd provides the sd_notify tool for this. The service file only needs the NotifyAccess option set so that systemd accepts notify events from that unit.

I added the message "GameMode is ready to be activated." in color Cyan when first started. 
When activated it says "GameMode is now active." in green. When inactive it says "GameMode is currently deactivated." 

Of course messages and colors are only a suggestion and can be changed. Also maybe i missed some places where the status message needs to be updated and somebody should take a look at this. 

Thanks.

