### PR TITLE
Added SIGTERM kill signal handling

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -133,6 +133,9 @@ int main(int argc, char *argv[])
 	if (signal(SIGINT, sigint_handler) == SIG_ERR) {
 		FATAL_ERRORNO("Could not catch SIGINT");
 	}
+	if (signal(SIGTERM, sigint_handler) == SIG_ERR) {
+		FATAL_ERRORNO("Could not catch SIGTERM");
+	}
 
 	/* Run the main dbus message loop */
 	game_mode_context_loop(context);


### PR DESCRIPTION
Hi, 

while playing around with the `sd_notify`enabled version i have noticed that the daemon never shuts itself down cleanly when being stopped by systemd. So it never logged "Quitting by request..." and resets the systemd status message. 

Apparently systemd sends a SIGTERM signal first to request the daemon to shutdown and after a delay SIGKILL will be send. So by handling SIGTERM the daemon can cleanly shutdown.