### PR TITLE
Create build directory

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,7 @@ set -e
 
 # Echo the rest so it's obvious
 set -x
+mkdir -p build
 meson --prefix=/usr build -Dwith-systemd-user-unit-dir=/etc/systemd/user
 cd build
 ninja


### PR DESCRIPTION
```
leijurv@swamp:~/Downloads$ wget https://github.com/FeralInteractive/gamemode/archive/1.0.tar.gz && tar -xvf 1.0.tar.gz
...
leijurv@swamp:~/Downloads/gamemode-1.0$ ./bootstrap.sh 
+ meson --prefix=/usr build -Dwith-systemd-user-unit-dir=/etc/systemd/user
Error during basic setup:

[Errno 2] No such file or directory: '/home/leijurv/Downloads/gamemode-1.0/build'
```

With this pull request:

```
leijurv@swamp:~/Downloads/gamemode-1.0$ ./bootstrap.sh 
+ meson --prefix=/usr build -Dwith-systemd-user-unit-dir=/etc/systemd/user
The Meson build system
Version: 0.29.0
Source dir: /home/leijurv/Downloads/gamemode-1.0
Build dir: /home/leijurv/Downloads/gamemode-1.0/build
Build type: native build
Build machine cpu family: x86_64
Build machine cpu: x86_64
Project name: gamemode
Native c compiler: cc (gcc 5.4.0-6ubuntu1)
```

`mkdir -p` will create the directory but not error if it's already present.