### PR TITLE
data: make service dbus-activatable

### DIFF
--- a/data/com.feralinteractive.GameMode.service.in
+++ b/data/com.feralinteractive.GameMode.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.feralinteractive.GameMode
 Exec=@BINDIR@/gamemoded -d
+SystemdService=gamemoded.service

--- a/data/meson.build
+++ b/data/meson.build
@@ -10,15 +10,16 @@ if with_systemd == true
         configuration: data_conf,
         install_dir: path_systemd_unit_dir,
     )
-else
-    # Install the D-BUS service file
-    configure_file(
-        input: 'com.feralinteractive.GameMode.service.in',
-        output: 'com.feralinteractive.GameMode.service',
-        configuration: data_conf,
-        install_dir: path_dbus_service_dir,
-    )
 endif
+
+# Install the D-BUS service file
+configure_file(
+  input: 'com.feralinteractive.GameMode.service.in',
+  output: 'com.feralinteractive.GameMode.service',
+  configuration: data_conf,
+  install_dir: path_dbus_service_dir,
+)
+
 
 # Install the Polkit action file in all cases
 configure_file(

--- a/meson.build
+++ b/meson.build
@@ -53,12 +53,12 @@ if with_systemd == true
         pkgconfig_systemd = dependency('systemd')
         path_systemd_unit_dir = pkgconfig_systemd.get_pkgconfig_variable('systemduserunitdir')
     endif
-else
-    # Set the dbus path as appropriate.
-    path_dbus_service_dir = get_option('with-dbus-service-dir')
-    if path_dbus_service_dir == ''
-        path_dbus_service_dir = join_paths(path_datadir, 'dbus-1', 'services')
-    endif
+endif
+
+# Set the dbus path as appropriate.
+path_dbus_service_dir = get_option('with-dbus-service-dir')
+if path_dbus_service_dir == ''
+  path_dbus_service_dir = join_paths(path_datadir, 'dbus-1', 'services')
 endif
 
 path_polkit_action_dir = join_paths(path_datadir, 'polkit-1', 'actions')
@@ -114,11 +114,10 @@ if with_systemd == true
 report += [
     '    systemd user unit directory:            @0@'.format(path_systemd_unit_dir),
 ]
-else
+endif
 report += [
     '    D-BUS service directory:                @0@'.format(path_dbus_service_dir),
 ]
-endif
 
 report += [
 


### PR DESCRIPTION
Always install the dbus service file and specify the systemd
unit file in it. This makes the service dbus-activatable and
thus we don't need to explicitly enable it (also we have one
less daemon running, if it is not needed).

I tested it by making sure it was not yet running and then did a `LD_PRELOAD=libgamemodeauto.so sleep 60`.

```
Jun 28 19:15:28 cobalt dbus-daemon[2021]: [session uid=1000 pid=2021] Activating via systemd: service name='com.feralinteractive.GameMode' unit='gamemoded.service' requested by ':1.638'...
Jun 28 19:15:28 cobalt systemd[1997]: Starting gamemoded...
Jun 28 19:15:28 cobalt /usr/bin/gamemoded[19114]: governor is set to [powersave]
Jun 28 19:15:28 cobalt dbus-daemon[2021]: [session uid=1000 pid=2021] Successfully activated service 'com.feralinteractive.GameMode'
Jun 28 19:15:28 cobalt /usr/bin/gamemoded[19114]: Successfully initialised bus with name [com.feralinteractive.GameMode]...
Jun 28 19:15:28 cobalt systemd[1997]: Started gamemoded.
Jun 28 19:15:28 cobalt /usr/bin/gamemoded[19114]: Adding game: 19113 [/usr/bin/sleep]
Jun 28 19:15:28 cobalt /usr/bin/gamemoded[19114]: Entering Game Mode...
Jun 28 19:15:28 cobalt /usr/bin/gamemoded[19114]: Requesting update of governor policy to performance
Jun 28 19:15:28 cobalt pkexec[19116]: pam_systemd(polkit-1:session): Cannot create session: Already running in a session
Jun 28 19:15:28 cobalt audit[19116]: USER_START pid=19116 uid=1000 auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=PAM:session_open grantors=pam_keyinit,pam_limits,pa...
Jun 28 19:15:28 cobalt pkexec[19116]: pam_unix(polkit-1:session): session opened for user root by (uid=1000)
Jun 28 19:15:28 cobalt pkexec[19116]: gicmo: Executing command [USER=root] [TTY=unknown] [CWD=/home/gicmo] [COMMAND=/usr/libexec/cpugovctl set performance]
Jun 28 19:15:28 cobalt gamemoded[19114]: Setting governors to performance
Jun 28 19:15:33 cobalt /usr/bin/gamemoded[19114]: Removing expired game [19113]...
Jun 28 19:15:33 cobalt /usr/bin/gamemoded[19114]: Removing game: 19113 [/usr/bin/sleep]
Jun 28 19:15:33 cobalt /usr/bin/gamemoded[19114]: Leaving Game Mode...
Jun 28 19:15:33 cobalt /usr/bin/gamemoded[19114]: Requesting update of governor policy to powersave
Jun 28 19:15:33 cobalt pkexec[19305]: pam_systemd(polkit-1:session): Cannot create session: Already running in a session
Jun 28 19:15:33 cobalt audit[19305]: USER_START pid=19305 uid=1000 auid=1000 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=PAM:session_open grantors=pam_keyinit,pam_limits,pa...
Jun 28 19:15:33 cobalt pkexec[19305]: pam_unix(polkit-1:session): session opened for user root by (uid=1000)
Jun 28 19:15:33 cobalt pkexec[19305]: gicmo: Executing command [USER=root] [TTY=unknown] [CWD=/home/gicmo] [COMMAND=/usr/libexec/cpugovctl set powersave]
Jun 28 19:15:33 cobalt gamemoded[19114]: Setting governors to powersave
```

```
→ systemctl --user status gamemoded
● gamemoded.service - gamemoded
   Loaded: loaded (/usr/lib/systemd/user/gamemoded.service; disabled; vendor preset: enabled)
   Active: active (running) since Thu 2018-06-28 19:15:28 EEST; 15min ago
 Main PID: 19114 (gamemoded)
   Status: "GameMode is currently deactivated."
   CGroup: /user.slice/user-1000.slice/user@1000.service/gamemoded.service
           └─19114 /usr/bin/gamemoded -l
```