### PR TITLE
Introduce libtool like library versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ This will also satisfy the build requirement `inih` by pulling it in as a git su
 ## Requesting GameMode
 
 ### Users
-After installing `libgamemodeauto.so` simply preload it into the game:
+After installing `libgamemodeauto.so.0` simply preload it into the game:
 ```bash
-LD_PRELOAD=/usr/\$LIB/libgamemodeauto.so ./game
+LD_PRELOAD=/usr/\$LIB/libgamemodeauto.so.0 ./game
 ```
 Or edit the steam launch options:
 ```bash
-LD_PRELOAD=$LD_PRELOAD:/usr/\$LIB/libgamemodeauto.so %command%
+LD_PRELOAD=$LD_PRELOAD:/usr/\$LIB/libgamemodeauto.so.0 %command%
 ```
 Please note the backslash here in `\$LIB` is required.
 

--- a/lib/gamemode_client.h
+++ b/lib/gamemode_client.h
@@ -152,7 +152,7 @@ __attribute__((always_inline)) static inline int internal_load_libgamemode(void)
 	void *libgamemode = NULL;
 
 	/* Try and load libgamemode */
-	libgamemode = dlopen("libgamemode.so", RTLD_NOW);
+	libgamemode = dlopen("libgamemode.so.0", RTLD_NOW);
 	if (!libgamemode) {
 		snprintf(internal_gamemode_client_error_string,
 		         sizeof(internal_gamemode_client_error_string),

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,5 +1,5 @@
 # Main client library to message the daemon
-shared_library(
+gamemode = shared_library(
     'gamemode',
     sources: [
         'client_impl.c',
@@ -15,7 +15,7 @@ libgamemode_includes = [
 ]
 
 # Small library to automatically use gamemode
-shared_library(
+gamemodeauto = shared_library(
     'gamemodeauto',
     sources: [
         'client_loader.c',
@@ -32,3 +32,28 @@ gamemode_headers = [
 ]
 
 install_headers(gamemode_headers)
+
+# Generate a pkg-config files
+pkg = import('pkgconfig')
+desc = 'GameMode temporarily applies game specific optimisations to the host OS.'
+pkg.generate(
+  name: 'gamemode',
+  description: desc,
+  filebase: 'gamemode',
+  version: meson.project_version(),
+  libraries: [
+    libdl
+  ],
+)
+
+pkg.generate(
+  name: 'gamemode',
+  description: desc,
+  filebase: 'gamemode-auto',
+  libraries: gamemodeauto,
+  version: meson.project_version(),
+  libraries_private: [
+    libdl
+  ],
+)
+

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,3 +1,10 @@
+# Libtool like versioning (current.revision.age) for the libraries
+# See https://www.sourceware.org/autobook/autobook/autobook_61.html#Library-Versioning
+lt_current = '0'
+lt_revision = '0'
+lt_age = '0'
+lt_version = '@0@.@1@.@2@'.format(lt_current, lt_age, lt_revision)
+
 # Main client library to message the daemon
 gamemode = shared_library(
     'gamemode',
@@ -8,6 +15,8 @@ gamemode = shared_library(
         dep_systemd,
     ],
     install: true,
+    soversion: lt_current,
+    version: lt_version,
 )
 
 libgamemode_includes = [
@@ -24,6 +33,8 @@ gamemodeauto = shared_library(
         libdl,
     ],
     install: true,
+    soversion: lt_current,
+    version: lt_version,
 )
 
 # Install the gamemode_client header


### PR DESCRIPTION
Addressing the problem brought up in #61 that for packaging in Fedora (and probably others, e.g. [debian](https://www.debian.org/doc/debian-policy/#document-ch-sharedlibs)) that shipped libraries must be versioned, we do so via libtool like versioning scheme (`current.revision.age`), which for now is just `0.0.0`. The client header then uses the versioned library, i.e. `libgamemode.so.0`.
Additionally provide package config files to ease development.