### PR TITLE
gamemode: Don't leak SCHED_ISO into children

### DIFF
--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -224,7 +224,7 @@ static void game_mode_apply_scheduler(GameModeContext *self, pid_t client)
 	 */
 	if (!(strcmp(softrealtime, "off") == 0) && (enable_softrealtime)) {
 		const struct sched_param p = { .sched_priority = 0 };
-		if (sched_setscheduler(client, SCHED_ISO, &p)) {
+		if (sched_setscheduler(client, SCHED_ISO | SCHED_RESET_ON_FORK, &p)) {
 			LOG_ERROR(
 			    "Setting client [%d] to SCHED_ISO failed with error %d, ignoring (your "
 			    "kernel may not support this).\n",


### PR DESCRIPTION
We should not leak `SCHED_ISO` into children processes. This is obviously
a no-op if launchers use the `LD_PRELOAD` method because every child would
also preload the gamemode library (except they patch the environment
before forking).

But for games supporting gamemode natively, this prevents leaking the
scheduler settings into child processes which is important because it
children may create high CPU usage which counterfeits the original idea
of this.

Apparently, this won't work for the nice value except we would intercept
the libc forking functions (which would be possible but not very
transparent and prone to compatibility problems). However, if we
implemented it, it shouldn't be part of this commit anyway.

Signed-off-by: Kai Krakow <kai@kaishome.de>