### PR TITLE
format-check: Optimize format-check.sh

### DIFF
--- a/scripts/format-check.sh
+++ b/scripts/format-check.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 # Simple script to check for clang-format compliance
-wget https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format
-chmod +x git-clang-format
 
-CLANG_FORMAT_OUTPUT=$(./git-clang-format HEAD^ HEAD --diff)
-if [[ ! ${CLANG_FORMAT_OUTPUT} == "no modified files to format" ]] && [[ ! -z ${CLANG_FORMAT_OUTPUT} ]]; then
-  echo "Failed clang format check:"
-  echo "${CLANG_FORMAT_OUTPUT}"
-  exit 1
+wget -Nq https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format
+
+if chmod +x git-clang-format; then
+  CLANG_FORMAT_OUTPUT=$(./git-clang-format HEAD^ HEAD --diff)
+  if [[ ! ${CLANG_FORMAT_OUTPUT} == "no modified files to format" ]] && [[ ! -z ${CLANG_FORMAT_OUTPUT} ]]; then
+    echo "Failed clang format check:"
+    echo "${CLANG_FORMAT_OUTPUT}"
+    exit 1
+  else
+    echo "Passed clang format check"
+  fi
 else
-  echo "Passed clang format check"
+  echo "git-clang-format not downloaded"
+  exit 1
 fi
-

--- a/scripts/format-check.sh
+++ b/scripts/format-check.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 # Simple script to check for clang-format compliance
 
+# Ensure we are at the project root
+cd "$(dirname $0)"/..
+
 wget -Nq https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format
 
 if chmod +x git-clang-format; then
+  if [[ "$1" == "--pre-commit" ]]; then
+    # used via .git/hooks/pre-commit:
+    # exec "$(dirname $0)"/../../scripts/format-check.sh --pre-commit
+    ./git-clang-format
+    exit
+  fi
   CLANG_FORMAT_OUTPUT=$(./git-clang-format HEAD^ HEAD --diff)
   if [[ ! ${CLANG_FORMAT_OUTPUT} == "no modified files to format" ]] && [[ ! -z ${CLANG_FORMAT_OUTPUT} ]]; then
     echo "Failed clang format check:"


### PR DESCRIPTION
This commit silences the standard output of wget to generate less noise
when using `format-check.sh` as a pre-commit hook.

It also doesn't redownload the file over and over again but only when
changes were detected. Previous behavior was wget creating numbered
versions by multiple downloads, thus it always used the first version
which was download. That is obviously wrong.

It errors out nicely now when the download failed.

Signed-off-by: Kai Krakow <kai@kaishome.de>