### PR TITLE
Identify original wine exe by PID

### DIFF
--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -144,7 +144,7 @@ void game_mode_context_loop(GameModeContext *context)
 	ret = sd_bus_open_user(&bus);
 
 	if (ret < 0) {
-		FATAL_ERROR("Failed to connect to the bus: %s", strerror(-ret));
+		FATAL_ERROR("Failed to connect to the bus: %s\n", strerror(-ret));
 	}
 
 	/* Create the object to allow connections */
@@ -156,13 +156,13 @@ void game_mode_context_loop(GameModeContext *context)
 	                               context);
 
 	if (ret < 0) {
-		FATAL_ERROR("Failed to install GameMode object: %s", strerror(-ret));
+		FATAL_ERROR("Failed to install GameMode object: %s\n", strerror(-ret));
 	}
 
 	/* Request our name */
 	ret = sd_bus_request_name(bus, "com.feralinteractive.GameMode", 0);
 	if (ret < 0) {
-		FATAL_ERROR("Failed to acquire service name: %s", strerror(-ret));
+		FATAL_ERROR("Failed to acquire service name: %s\n", strerror(-ret));
 	}
 
 	LOG_MSG("Successfully initialised bus with name [%s]...\n", "com.feralinteractive.GameMode");
@@ -172,7 +172,7 @@ void game_mode_context_loop(GameModeContext *context)
 	for (;;) {
 		ret = sd_bus_process(bus, NULL);
 		if (ret < 0) {
-			FATAL_ERROR("Failure when processing the bus: %s", strerror(-ret));
+			FATAL_ERROR("Failure when processing the bus: %s\n", strerror(-ret));
 		}
 
 		/* We're done processing */
@@ -183,7 +183,7 @@ void game_mode_context_loop(GameModeContext *context)
 		/* Wait for more */
 		ret = sd_bus_wait(bus, (uint64_t)-1);
 		if (ret < 0 && -ret != EINTR) {
-			FATAL_ERROR("Failure when waiting on bus: %s", strerror(-ret));
+			FATAL_ERROR("Failure when waiting on bus: %s\n", strerror(-ret));
 		}
 	}
 }

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -454,14 +454,17 @@ bool game_mode_context_register(GameModeContext *self, pid_t client)
 		fputs("OOM\n", stderr);
 		return false;
 	}
-	cl->executable = game_mode_context_find_exe(client);
-	if (!cl->executable)
-		goto error_cleanup;
 
+	/* Check the PID first to spare a potentially expensive lookup for the exe */
 	if (game_mode_context_has_client(self, client)) {
 		LOG_ERROR("Addition requested for already known process [%d]\n", client);
 		goto error_cleanup;
 	}
+
+	/* Lookup the executable */
+	cl->executable = game_mode_context_find_exe(client);
+	if (!cl->executable)
+		goto error_cleanup;
 
 	/* Check our blacklist and whitelist */
 	if (!config_get_client_whitelisted(self->config, cl->executable)) {

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -75,6 +75,17 @@ POSSIBILITY OF SUCH DAMAGE.
 	(snprintf(b, sizeof(b), s, __VA_ARGS__) < (ssize_t)sizeof(b) ? strndup(b, sizeof(b)) : NULL)
 
 /**
+ * Helper function: Test, if haystack ends with needle.
+ */
+static inline const char *strtail(const char *haystack, const char *needle)
+{
+	char *pos = strstr(haystack, needle);
+	if (pos && (strlen(pos) == strlen(needle)))
+		return pos;
+	return NULL;
+}
+
+/**
  * The GameModeClient encapsulates the remote connection, providing a list
  * form to contain the pid and credentials.
  */

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -131,7 +131,7 @@ static volatile bool had_context_init = false;
 
 static GameModeClient *game_mode_client_new(pid_t pid, char *exe);
 static void game_mode_client_free(GameModeClient *client);
-static bool game_mode_context_has_client(GameModeContext *self, pid_t client);
+static const GameModeClient *game_mode_context_has_client(GameModeContext *self, pid_t client);
 static int game_mode_context_num_clients(GameModeContext *self);
 static void *game_mode_context_reaper(void *userdata);
 static void game_mode_context_enter(GameModeContext *self);
@@ -439,15 +439,15 @@ static void game_mode_context_auto_expire(GameModeContext *self)
 /**
  * Determine if the client is already known to the context
  */
-static bool game_mode_context_has_client(GameModeContext *self, pid_t client)
+static const GameModeClient *game_mode_context_has_client(GameModeContext *self, pid_t client)
 {
-	bool found = false;
+	const GameModeClient *found = NULL;
 	pthread_rwlock_rdlock(&self->rwlock);
 
 	/* Walk all clients and find a matching pid */
 	for (GameModeClient *cl = self->client; cl; cl = cl->next) {
 		if (cl->pid == client) {
-			found = true;
+			found = cl;
 			break;
 		}
 	}

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -455,6 +455,8 @@ bool game_mode_context_register(GameModeContext *self, pid_t client)
 		return false;
 	}
 	cl->executable = game_mode_context_find_exe(client);
+	if (!cl->executable)
+		goto error_cleanup;
 
 	if (game_mode_context_has_client(self, client)) {
 		LOG_ERROR("Addition requested for already known process [%d]\n", client);

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -65,6 +65,11 @@ POSSIBILITY OF SUCH DAMAGE.
  */
 #define CLAMP(lbound, ubound, value) MIN(MIN(lbound, ubound), MAX(MAX(lbound, ubound), value))
 
+/* Little helper to safely print into a buffer, returns a newly allocated string
+ */
+#define safe_snprintf(b, s, ...)                                                                   \
+	(snprintf(b, sizeof(b), s, __VA_ARGS__) < (ssize_t)sizeof(b) ? strndup(b, sizeof(b)) : NULL)
+
 /**
  * The GameModeClient encapsulates the remote connection, providing a list
  * form to contain the pid and credentials.


### PR DESCRIPTION
This PR adds a series of commits to detect the original game exe name from the PID if GameMode is used to run wine programs. Without this, we are not able to blacklist specific games or executables because every wine PID identifies as `wine-preloader` or `wine64-preloader`.

Please review and share your ideas. ~~I still have some fixes and todos to work on. But if you think this isn't worth inclusion or should go another route, it's good to have feedback early.~~