### PR TITLE
Fix access to uninitialized values (valgrind)

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -221,6 +221,8 @@ static void load_config_files(GameModeConfig *self)
 	memset(self->endscripts, 0, sizeof(self->endscripts));
 	memset(self->defaultgov, 0, sizeof(self->defaultgov));
 	memset(self->desiredgov, 0, sizeof(self->desiredgov));
+	memset(self->softrealtime, 0, sizeof(self->softrealtime));
+	self->renice = 0; /* 0 = use default */
 	self->reaper_frequency = DEFAULT_REAPER_FREQ;
 
 	/*


### PR DESCRIPTION
Fix what was reported by valgrind:

```
==8458==
==8458== HEAP SUMMARY:
==8458==     in use at exit: 11,677 bytes in 27 blocks
==8458==   total heap usage: 768 allocs, 741 frees, 397,008 bytes allocated
==8458==
==8458== Searching for pointers to 27 not-freed blocks
==8458== Checked 206,624 bytes
==8458==
==8458== LEAK SUMMARY:
==8458==    definitely lost: 0 bytes in 0 blocks
==8458==    indirectly lost: 0 bytes in 0 blocks
==8458==      possibly lost: 0 bytes in 0 blocks
==8458==    still reachable: 11,677 bytes in 27 blocks
==8458==         suppressed: 0 bytes in 0 blocks
==8458== Reachable blocks (those to which a pointer was found) are not shown.
==8458== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==8458==
==8458== Use --track-origins=yes to see where uninitialised values come from
==8458== ERROR SUMMARY: 200 errors from 10 contexts (suppressed: 0 from 0)
==8458==
==8458== 20 errors in context 1 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x10BD18: game_mode_apply_scheduler (gamemode.c:237)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 2 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x4A0C4DC: strcmp (vg_replace_strmem.c:846)
==8458==    by 0x10BD15: game_mode_apply_scheduler (gamemode.c:237)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 3 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x10BCDB: game_mode_apply_scheduler (gamemode.c:232)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 4 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x4A0C4DC: strcmp (vg_replace_strmem.c:846)
==8458==    by 0x10BCD8: game_mode_apply_scheduler (gamemode.c:232)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 5 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x53AB44C: vfprintf (vfprintf.c:1642)
==8458==    by 0x53B2C5D: printf (printf.c:33)
==8458==    by 0x10BBA2: game_mode_apply_scheduler (gamemode.c:201)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 6 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x53AA9DA: vfprintf (vfprintf.c:1642)
==8458==    by 0x53B2C5D: printf (printf.c:33)
==8458==    by 0x10BBA2: game_mode_apply_scheduler (gamemode.c:201)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 7 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x53A6FF5: _itoa_word (_itoa.c:179)
==8458==    by 0x53AA922: vfprintf (vfprintf.c:1642)
==8458==    by 0x53B2C5D: printf (printf.c:33)
==8458==    by 0x10BBA2: game_mode_apply_scheduler (gamemode.c:201)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 8 of 10:
==8458== Use of uninitialised value of size 8
==8458==    at 0x53A6FE8: _itoa_word (_itoa.c:179)
==8458==    by 0x53AA922: vfprintf (vfprintf.c:1642)
==8458==    by 0x53B2C5D: printf (printf.c:33)
==8458==    by 0x10BBA2: game_mode_apply_scheduler (gamemode.c:201)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 9 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x53AB20A: vfprintf (vfprintf.c:1642)
==8458==    by 0x53B2C5D: printf (printf.c:33)
==8458==    by 0x10BBA2: game_mode_apply_scheduler (gamemode.c:201)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458==
==8458== 20 errors in context 10 of 10:
==8458== Conditional jump or move depends on uninitialised value(s)
==8458==    at 0x10BB44: game_mode_apply_scheduler (gamemode.c:200)
==8458==    by 0x10C7D7: game_mode_context_register (gamemode.c:445)
==8458==    by 0x10D4E6: method_register_game (dbus_messaging.c:79)
==8458==    by 0x4CB795B: method_callbacks_run (bus-objects.c:404)
==8458==    by 0x4CB795B: object_find_and_run (bus-objects.c:1262)
==8458==    by 0x4CB8D38: bus_process_object (bus-objects.c:1378)
==8458==    by 0x4CC9251: process_message (sd-bus.c:2663)
==8458==    by 0x4CC9251: process_running (sd-bus.c:2705)
==8458==    by 0x4CC9251: bus_process_internal (sd-bus.c:2924)
==8458==    by 0x10D8B9: game_mode_context_loop (dbus_messaging.c:173)
==8458==    by 0x10B7C4: main (main.c:186)
==8458==
==8458== ERROR SUMMARY: 200 errors from 10 contexts (suppressed: 0 from 0)
```

Signed-off-by: Kai Krakow <kai@kaishome.de>