### PR TITLE
Configurable prefix path

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,15 +19,18 @@ if [ ! -f "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor" ]; then
 	[[ $REPLY =~ ^[Yy]$ ]]
 fi
 
+# accept a prefix value as: prefix=/path ./bootstrap.sh
+: ${prefix:=/usr}
+
 # Echo the rest so it's obvious
 set -x
-meson --prefix=/usr build -Dwith-systemd-user-unit-dir=/etc/systemd/user
+meson --prefix=$prefix build -Dwith-systemd-user-unit-dir=/etc/systemd/user
 cd build
 ninja
 
 # Verify user wants to install
 set +x
-read -p "Install to /usr? [Yy] " -r
+read -p "Install to $prefix? [Yy] " -r
 [[ $REPLY =~ ^[Yy]$ ]]
 set -x
 


### PR DESCRIPTION
This PR makes the prefix path in `bootstrap.sh` configurable by setting a temporary variable during invocation.

    $ prefix=/alternate/path ./bootstrap.sh

In a separate commit, the default is also changed to `/usr/local` as it is customary to install external software under `/usr/local`.  If the change of default is not acceptable, please feel free to revert it (or let me know, and I'll revert).