### PR TITLE
Enable and start service in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,3 +38,13 @@ sudo ninja install
 
 # Reload systemd configuration so that it picks up the new service.
 systemctl --user daemon-reload
+
+# Verify user wants to activate now
+set +x
+read -p "Activate daemon now? [Yy] " -r
+[[ $REPLY =~ ^[Yy]$ ]]
+set -x
+
+systemctl --user enable gamemoded.service
+systemctl --user start gamemoded.service
+


### PR DESCRIPTION
As systemd service installation is not trivial I believe many non-power users will benefit from bootstrap handling service activation. Please consider merging this!

And thanks a lot for gamemode!!!