### PR TITLE
Add code to disable the screensaver during Game Mode

### DIFF
--- a/daemon/dbus_messaging.h
+++ b/daemon/dbus_messaging.h
@@ -39,3 +39,8 @@ POSSIBILITY OF SUCH DAMAGE.
  * Run the main D-BUS loop "forever"
  */
 void game_mode_context_loop(GameModeContext *context);
+
+/**
+ * Inhibit the screensaver
+ */
+int game_mode_inhibit_screensaver(bool inhibit);

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -33,6 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "gamemode.h"
 #include "daemon_config.h"
+#include "dbus_messaging.h"
 #include "governors-query.h"
 #include "governors.h"
 #include "helpers.h"
@@ -202,6 +203,9 @@ static void game_mode_context_enter(GameModeContext *self)
 			memset(self->initial_cpu_mode, 0, sizeof(self->initial_cpu_mode));
 		}
 	}
+
+	/* Inhibit the screensaver */
+	game_mode_inhibit_screensaver(true);
 }
 
 /**
@@ -214,6 +218,9 @@ static void game_mode_context_leave(GameModeContext *self)
 {
 	LOG_MSG("Leaving Game Mode...\n");
 	sd_notifyf(0, "STATUS=%sGameMode is currently deactivated.%s\n", "\x1B[1;36m", "\x1B[0m");
+
+	/* UnInhibit the screensaver */
+	game_mode_inhibit_screensaver(false);
 
 	/* Reset the governer state back to initial */
 	if (self->initial_cpu_mode[0] != '\0') {


### PR DESCRIPTION
Currently just requests on the `org.freedesktop.ScreenSaver` bus, took a while to get the details exactly right but appears to work.

FWIW SDL does a [little more](https://github.com/SDL-mirror/SDL/blob/master/src/video/x11/SDL_x11events.c#L1464) - it implements a tickle as well as trying to use X11 directly. GameMode could do the same but this might well do for now.

Note: an `Inhibit` call will also be cleaned up once the calling process dies (in this case, the daemon), so we're safe in the case of a crash or bailout.

Should provide the functionality that @NRG-R9T wanted in #94.