### PR TITLE
Have the full bootstrap script run in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: c
 compiler: gcc
 sudo: false
+dist: xenial
 
 addons:
   apt:
     packages:
-      - clang-format-3.4
+      - clang-format
 
 script:
   - ./scripts/format-check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
+dist: xenial
 language: c
 compiler: gcc
 sudo: false
-dist: xenial
 
 addons:
   apt:
     packages:
       - clang-format
+      - python3-pip
+      - python3-setuptools
+      - libsystemd-dev
+      - ninja-build
+
+before_script:
+  - pip3 install wheel
+  - pip3 install meson
+  - meson --version
 
 script:
   - ./scripts/format-check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ before_script:
 
 script:
   - ./scripts/format-check.sh
+  - ./bootstrap.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ before_script:
 script:
   - ./scripts/format-check.sh
   - ./bootstrap.sh
+  - gamemoded -v

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,9 +14,11 @@ if [ ! -f "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor" ]; then
 	echo "This probably means that you have disabled processor scheduling features in your BIOS. See README.md (or GitHub issue #44) for more information."
 	echo "This means GameMode's CPU governor control feature will not work (other features will still work)."
 
-	# Allow to continue the install, as gamemode has other useful features
-	read -p "Would you like to continue anyway [Y/N]? " -r
-	[[ $REPLY =~ ^[Yy]$ ]]
+	if [ "$TRAVIS" != "true" ]; then
+		# Allow to continue the install, as gamemode has other useful features
+		read -p "Would you like to continue anyway [Y/N]? " -r
+		[[ $REPLY =~ ^[Yy]$ ]]
+	fi
 fi
 
 # accept a prefix value as: prefix=/path ./bootstrap.sh
@@ -30,8 +32,10 @@ ninja
 
 # Verify user wants to install
 set +x
-read -p "Install to $prefix? [Yy] " -r
-[[ $REPLY =~ ^[Yy]$ ]]
+if [ "$TRAVIS" != "true" ]; then
+	read -p "Install to $prefix? [Yy] " -r
+	[[ $REPLY =~ ^[Yy]$ ]]
+fi
 set -x
 
 sudo ninja install

--- a/daemon/gamemode-sched.c
+++ b/daemon/gamemode-sched.c
@@ -41,6 +41,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/resource.h>
 #include <sys/sysinfo.h>
 
+/* SCHED_ISO may not be defined as it is a reserved value not yet
+ * implemented in official kernel sources, see linux/sched.h.
+ */
+#ifndef SCHED_ISO
+#define SCHED_ISO 4
+#endif
+
 /**
  * Priority to renice the process to.
  */

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -44,13 +44,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stdatomic.h>
 #include <systemd/sd-daemon.h>
 
-/* SCHED_ISO may not be defined as it is a reserved value not yet
- * implemented in official kernel sources, see linux/sched.h.
- */
-#ifndef SCHED_ISO
-#define SCHED_ISO 4
-#endif
-
 /**
  * The GameModeClient encapsulates the remote connection, providing a list
  * form to contain the pid and credentials.


### PR DESCRIPTION
Travis now has `Xenial`! 🎉 

Use this to install the dependencies needed to run `bootstrap.sh` to verify that the full compile, install, and script itself work.

It doesn't look like a travis docker has dbus activated however, so we can't run `-t` yet, will need to consider options for that.