### PR TITLE
Add more test coverage

### DIFF
--- a/daemon/external-helper.h
+++ b/daemon/external-helper.h
@@ -31,5 +31,10 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#define EXTERNAL_BUFFER_MAX 1024
+
 /* Run an external process and capture the return value */
 int run_external_process(const char *const *exec_args);
+
+/* Run an external process and capture the return value as well as output */
+int run_external_process_get_output(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -240,6 +240,44 @@ static int run_dual_client_tests(void)
 }
 
 /**
+ * game_mode_run_feature_tests runs a set of tests for each current feature (based on the current
+ * config) returns 0 for success, -1 for failure
+ */
+static int game_mode_run_feature_tests(void)
+{
+	int status = 0;
+	fprintf(stdout, "   *feature tests*\n");
+
+	/* If we reach here, we should assume the basic requests and register functions are working */
+
+	/* Does the CPU governor get set properly? */
+	/* TODO */
+
+	/* Do custom scripts run? */
+	/* TODO */
+
+	/* Does the screensaver get inhibited? */
+	/* TODO */
+
+	/* Do GPU optimisations get applied? */
+	/* TODO */
+
+	/* Was the process reniced? */
+	/* TODO */
+
+	/* Was the scheduling applied? */
+	/* TODO */
+
+	/* Were io priorities changed? */
+	/* TODO */
+
+	if (status != -1)
+		fprintf(stdout, "       *passed*%s\n", status > 0 ? " (with optional failures)" : "");
+
+	return status;
+}
+
+/**
  * game_mode_run_client_tests runs a set of tests of the client code
  * we simply verify that the client can request the status and recieves the correct results
  *
@@ -256,6 +294,10 @@ int game_mode_run_client_tests()
 
 	/* Run the dual client tests */
 	if (run_dual_client_tests() != 0)
+		return -1;
+
+	/* Run the feature tests */
+	if (game_mode_run_feature_tests() != 0)
 		return -1;
 
 	return status;

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -246,7 +246,7 @@ static int run_dual_client_tests(void)
 static int game_mode_run_feature_tests(void)
 {
 	int status = 0;
-	fprintf(stdout, "   *feature tests*\n");
+	LOG_MSG("   *feature tests*\n");
 
 	/* If we reach here, we should assume the basic requests and register functions are working */
 
@@ -272,7 +272,7 @@ static int game_mode_run_feature_tests(void)
 	/* TODO */
 
 	if (status != -1)
-		fprintf(stdout, "       *passed*%s\n", status > 0 ? " (with optional failures)" : "");
+		LOG_MSG("       *passed*%s\n", status > 0 ? " (with optional failures)" : "");
 
 	return status;
 }

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -124,7 +124,7 @@ static int verify_other_client_connected(void)
  */
 static int run_basic_client_tests(void)
 {
-	LOG_MSG("   *basic client tests*\n");
+	LOG_MSG(":: Basic client tests\n");
 
 	/* First verify that gamemode is not currently active on the system
 	 * As well as it being currently installed and queryable
@@ -152,7 +152,7 @@ static int run_basic_client_tests(void)
 	if (verify_deactivated() != 0)
 		return -1;
 
-	LOG_MSG("       *passed*\n");
+	LOG_MSG(":: Passed\n\n");
 
 	return 0;
 }
@@ -165,7 +165,7 @@ static int run_dual_client_tests(void)
 	int status = 0;
 
 	/* Try running some process interop tests */
-	LOG_MSG("   *dual clients tests*\n");
+	LOG_MSG(":: Dual client tests\n");
 
 	/* Get the current path to this binary */
 	char mypath[PATH_MAX];
@@ -227,7 +227,7 @@ static int run_dual_client_tests(void)
 	// Wait for the child to finish up
 	int wstatus;
 	while (waitpid(child, &wstatus, WNOHANG) == 0) {
-		LOG_MSG("   Waiting for child to quit...\n");
+		LOG_MSG("...Waiting for child to quit...\n");
 		usleep(10000);
 	}
 
@@ -236,7 +236,7 @@ static int run_dual_client_tests(void)
 		return -1;
 
 	if (status == 0)
-		LOG_MSG("       *passed*\n");
+		LOG_MSG(":: Passed\n\n");
 
 	return status;
 }
@@ -248,7 +248,7 @@ static int run_dual_client_tests(void)
 static int game_mode_run_feature_tests(void)
 {
 	int status = 0;
-	LOG_MSG("   *feature tests*\n");
+	LOG_MSG(":: Feature tests\n");
 
 	/* If we reach here, we should assume the basic requests and register functions are working */
 
@@ -261,6 +261,8 @@ static int game_mode_run_feature_tests(void)
 	/* Does the CPU governor get set properly? */
 	int cpustatus = 0;
 	{
+		LOG_MSG("::: Verifying CPU governor setting\n");
+
 		/* get the two config parameters we care about */
 		char desiredgov[CONFIG_VALUE_MAX] = { 0 };
 		config_get_desired_governor(config, desiredgov);
@@ -312,6 +314,8 @@ static int game_mode_run_feature_tests(void)
 	/* Do custom scripts run? */
 	int scriptstatus = 0;
 	{
+		LOG_MSG("::: Verifying Scripts\n");
+
 		/* Grab the scripts */
 		char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		memset(scripts, 0, sizeof(scripts));
@@ -347,7 +351,9 @@ static int game_mode_run_feature_tests(void)
 	/* TODO */
 
 	if (status != -1)
-		LOG_MSG("       *passed*%s\n", status > 0 ? " (with optional failures)" : "");
+		LOG_MSG(":: Passed%s\n\n", status > 0 ? " (with optional failures)" : "");
+	else
+		LOG_ERROR(":: Failed!\n");
 
 	return status;
 }
@@ -361,19 +367,27 @@ static int game_mode_run_feature_tests(void)
 int game_mode_run_client_tests()
 {
 	int status = 0;
-	LOG_MSG("Running tests...\n");
+	LOG_MSG(": Running tests\n\n");
 
 	/* Run the basic tests */
 	if (run_basic_client_tests() != 0)
-		return -1;
+		status = -1;
 
 	/* Run the dual client tests */
 	if (run_dual_client_tests() != 0)
-		return -1;
+		status = -1;
 
-	/* Run the feature tests */
-	if (game_mode_run_feature_tests() != 0)
-		return -1;
+	if (status != 0) {
+		LOG_MSG(": Client tests failed, skipping feature tests\n");
+	} else {
+		/* Run the feature tests */
+		status = game_mode_run_feature_tests();
+	}
+
+	if (status >= 0)
+		LOG_MSG(": All Tests Passed%s!\n", status > 0 ? " (with optional failures)" : "");
+	else
+		LOG_MSG(": Tests Failed!\n");
 
 	return status;
 }

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -310,7 +310,26 @@ static int game_mode_run_feature_tests(void)
 	}
 
 	/* Do custom scripts run? */
-	/* TODO */
+	int scriptstatus = 0;
+	{
+		/* Grab the scripts */
+		char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
+		memset(scripts, 0, sizeof(scripts));
+		config_get_gamemode_start_scripts(config, scripts);
+
+		if (scripts[0][0] != '\0') {
+			/* Print out the scripts to run */
+			LOG_MSG("Custom scripts:\n");
+
+			int i = 0;
+			while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX)
+				LOG_MSG("%s\n", scripts[i]);
+		}
+
+		/* TODO: Somehow verify these get run
+		 * Possibly by watching if the the binary part gets run?
+		 */
+	}
 
 	/* Does the screensaver get inhibited? */
 	/* TODO */

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -223,13 +223,13 @@ static int run_dual_client_tests(void)
 	}
 
 	/* Give the child a chance to finish */
-	usleep(10000);
+	usleep(100000);
 
 	// Wait for the child to finish up
 	int wstatus;
 	while (waitpid(child, &wstatus, WNOHANG) == 0) {
 		LOG_MSG("...Waiting for child to quit...\n");
-		usleep(10000);
+		usleep(100000);
 	}
 
 	/* Verify that gamemode is now innactive */

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -378,18 +378,15 @@ static int game_mode_run_feature_tests(void)
 	}
 
 	/* Does the screensaver get inhibited? */
-	/* TODO */
+	/* TODO: Unknown if this is testable, org.freedesktop.ScreenSaver has no query method */
 
 	/* Do GPU optimisations get applied? */
 	/* TODO */
 
 	/* Was the process reniced? */
-	/* TODO */
-
 	/* Was the scheduling applied? */
-	/* TODO */
-
 	/* Were io priorities changed? */
+	/* Note: These don't get cleared up on un-register, so will have already been applied */
 	/* TODO */
 
 	if (status != -1)

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -259,8 +259,8 @@ static int game_mode_run_feature_tests(void)
 	config_init(config);
 
 	/* Does the CPU governor get set properly? */
-	int cpustatus = 0;
 	{
+		int cpustatus = 0;
 		LOG_MSG("::: Verifying CPU governor setting\n");
 
 		/* get the two config parameters we care about */
@@ -308,6 +308,13 @@ static int game_mode_run_feature_tests(void)
 				          currentgov);
 				cpustatus = -1;
 			}
+		}
+
+		if (cpustatus == 0)
+			LOG_MSG("::: Passed\n");
+		else {
+			LOG_MSG("::: Failed!\n");
+			status = 1;
 		}
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "daemon_config.h"
 #include "gamemode_client.h"
 #include "governors-query.h"
+#include "gpu-control.h"
 
 /* Initial verify step to ensure gamemode isn't already active */
 static int verify_gamemode_initial(void)
@@ -381,7 +382,23 @@ static int game_mode_run_feature_tests(void)
 	/* TODO: Unknown if this is testable, org.freedesktop.ScreenSaver has no query method */
 
 	/* Do GPU optimisations get applied? */
-	/* TODO */
+	{
+		/* First get current GPU values */
+		GameModeGPUInfo gpuinfo;
+		gpuinfo.device = config_get_gpu_device(config);
+		gpuinfo.vendor = config_get_gpu_vendor(config);
+
+		if( gpuinfo.vendor == Vendor_NVIDIA )
+			gpuinfo.nv_perf_level = config_get_nv_perf_level(config);
+
+		if( game_mode_get_gpu(&gpuinfo) != 0 )
+		{
+			LOG_ERROR("Could not get current GPU info, see above!\n");
+			status = 1;
+		}
+
+		/* TODO continue to run gamemode and check GPU stats */
+	}
 
 	/* Was the process reniced? */
 	/* Was the scheduling applied? */

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -144,3 +144,4 @@ typedef struct GameModeGPUInfo GameModeGPUInfo;
 int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info);
 void game_mode_free_gpu(GameModeGPUInfo **info);
 int game_mode_apply_gpu(const GameModeGPUInfo *info, bool apply);
+int game_mode_get_gpu(GameModeGPUInfo *info);

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -283,17 +283,19 @@ int main(int argc, char *argv[])
 		info.vendor = get_vendor(argv[1]);
 		info.device = get_device(argv[2]);
 
-		if (info.vendor == Vendor_NVIDIA)
+		if (info.vendor == Vendor_NVIDIA && argc > 4)
 			info.nv_perf_level = get_generic_value(argv[4]);
 
 		/* Fetch the state and print it out */
 		switch (info.vendor) {
 		case Vendor_NVIDIA:
 			/* Get nvidia power level */
-			get_gpu_state_nv(&info);
+			if( get_gpu_state_nv(&info) != 0 )
+				exit(EXIT_FAILURE);
 			break;
 		case Vendor_AMD:
-			get_gpu_state_amd(&info);
+			if( get_gpu_state_amd(&info) != 0)
+				exit(EXIT_FAILURE);
 			break;
 		default:
 			printf("Currently unsupported GPU vendor 0x%04x, doing nothing!\n", (short)info.vendor);
@@ -316,7 +318,7 @@ int main(int argc, char *argv[])
 		info.core = get_generic_value(argv[4]);
 		info.mem = get_generic_value(argv[5]);
 
-		if (info.vendor == Vendor_NVIDIA)
+		if (info.vendor == Vendor_NVIDIA && argc > 6)
 			info.nv_perf_level = get_generic_value(argv[6]);
 
 		printf("gpuclockctl setting core:%ld mem:%ld on device:%ld with vendor 0x%04x\n",

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -155,16 +155,8 @@ int main(int argc, char *argv[])
 			exit(EXIT_SUCCESS);
 			break;
 		case 't':
-			if ((status = game_mode_run_client_tests()) == 0) {
-				LOG_MSG("gamemode tests succeeded\n");
-				exit(EXIT_SUCCESS);
-			} else if (status == -1) {
-				LOG_ERROR("gamemode tests failed\n");
-				exit(EXIT_FAILURE);
-			} else {
-				LOG_ERROR("gamemode test results unknown: %d\n", status);
-				exit(EXIT_FAILURE);
-			}
+			status = game_mode_run_client_tests();
+			exit(status);
 			break;
 		case 'v':
 			LOG_MSG(VERSION_TEXT);


### PR DESCRIPTION
This PR adds tests for the following tests and features:

Internal:
- `game_mode_get_gpu` to get the current GPU settings (to be used more later)
- `run_external_process_get_output` to get output for an external process
- `gpuclockctl` can now get the state on nvidia (amd pending)
- `gpuclockctl` now warns about a missing `DISPLAY` variable, to help diagnosis

Testing implemented for:
- `gamemoderun`
- reaper thread (same test as above)
- cpu governor setting
- custom script verification (just checks they can run)
- gpu optimization (only NV for now, AMD work still pending)

Still missing: renice, ioprio and sched tests, but due to current behavior, these are a little more complicated.

Example testing output:
```
$ gamemoded -t
: Loading config
Loading config file [/etc/gamemode.ini]
Loading config file [/home/mdiluz/.config/gamemode.ini]
: Running tests

:: Basic client tests
:: Passed

:: Dual client tests
gamemode request succeeded and is active
Quitting by request...
...Waiting for child to quit...
:: Passed

:: Gamemoderun and reaper thread tests
...Waiting for child to quit...
...Waiting for reaper thread (reaper_frequency set to 10 seconds)...
:: Passed

:: Feature tests
::: Verifying CPU governor setting
::: Passed
::: Verifying Scripts
:::: Running start script [notify-send "GameMode started"]
:::: Passed
:::: Running end script [notify-send "GameMode ended"]
:::: Passed
::: Passed
::: Verifying GPU Optimisations
Configured with vendor:0x10de device:0 core:5 mem:10 (nv_perf_level:1)
::: Passed
:: Passed

: All Tests Passed!
```
