### PR TITLE
Detect the GPU vendor automatically

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -152,7 +152,8 @@ static bool get_long_value(const char *value_name, const char *value, long *outp
 /*
  * Get a long value from a hex string
  */
-static bool get_long_value_hex(const char *value_name, const char *value, long *output)
+__attribute__((unused)) static bool get_long_value_hex(const char *value_name, const char *value,
+                                                       long *output)
 {
 	char *end = NULL;
 	long config_value = strtol(value, &end, 16);

--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -87,7 +87,6 @@ struct GameModeConfig {
 		long reaper_frequency;
 
 		char apply_gpu_optimisations[CONFIG_VALUE_MAX];
-		long gpu_vendor;
 		long gpu_device;
 		long nv_core_clock_mhz_offset;
 		long nv_mem_clock_mhz_offset;
@@ -231,8 +230,6 @@ static int inih_handler(void *user, const char *section, const char *name, const
 		/* GPU subsection */
 		if (strcmp(name, "apply_gpu_optimisations") == 0) {
 			valid = get_string_value(value, self->values.apply_gpu_optimisations);
-		} else if (strcmp(name, "gpu_vendor") == 0) {
-			valid = get_long_value_hex(name, value, &self->values.gpu_vendor);
 		} else if (strcmp(name, "gpu_device") == 0) {
 			valid = get_long_value(name, value, &self->values.gpu_device);
 		} else if (strcmp(name, "nv_core_clock_mhz_offset") == 0) {
@@ -556,7 +553,6 @@ void config_get_apply_gpu_optimisations(GameModeConfig *self, char value[CONFIG_
 }
 
 /* Define the getters for GPU values */
-DEFINE_CONFIG_GET(gpu_vendor)
 DEFINE_CONFIG_GET(gpu_device)
 DEFINE_CONFIG_GET(nv_core_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_mem_clock_mhz_offset)

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -134,7 +134,6 @@ long config_get_ioprio_value(GameModeConfig *self);
  * Get various config info for gpu optimisations
  */
 void config_get_apply_gpu_optimisations(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
-long config_get_gpu_vendor(GameModeConfig *self);
 long config_get_gpu_device(GameModeConfig *self);
 long config_get_nv_core_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -71,8 +71,10 @@ int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info)
 	memset(new_info, 0, sizeof(GameModeGPUInfo));
 
 	/* Get the config parameters */
-	new_info->vendor = config_get_gpu_vendor(config);
 	new_info->device = config_get_gpu_device(config);
+
+	/* TODO fill in GPU vendor */
+	new_info->vendor = 0;
 
 	/* verify device ID */
 	if (new_info->device == -1) {
@@ -86,10 +88,9 @@ int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info)
 	/* verify GPU vendor */
 	if (!GPUVendorValid(new_info->vendor)) {
 		LOG_ERROR(
-		    "Invalid gpu_vendor value (0x%04x) set in configuration, will not apply "
-		    "optimisations!\n",
+		    "Unknown vendor value (0x%04x) found, cannot apply optimisations!\n",
 		    (unsigned int)new_info->vendor);
-		LOG_ERROR("Possible values are: 0x%04x (NVIDIA) 0x%04x (AMD) 0x%04x (Intel)\n",
+		LOG_ERROR("Known values are: 0x%04x (NVIDIA) 0x%04x (AMD) 0x%04x (Intel)\n",
 		          Vendor_NVIDIA,
 		          Vendor_AMD,
 		          Vendor_Intel);

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -421,15 +421,14 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	/* Get current GPU values */
 	GameModeGPUInfo gpuinfo;
 	gpuinfo.device = config_get_gpu_device(config);
-	gpuinfo.vendor = config_get_gpu_vendor(config);
-
-	if (gpuinfo.vendor == Vendor_NVIDIA)
-		gpuinfo.nv_perf_level = config_get_nv_perf_level(config);
 
 	if (game_mode_get_gpu(&gpuinfo) != 0) {
 		LOG_ERROR("Could not get current GPU info, see above!\n");
 		return -1;
 	}
+
+	if (gpuinfo.vendor == Vendor_NVIDIA)
+		gpuinfo.nv_perf_level = config_get_nv_perf_level(config);
 
 	/* Store the original values */
 	long original_core = gpuinfo.core;

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -43,7 +43,7 @@ inhibit_screensaver=1
 ; Setting this to the keyphrase "accept-responsibility" will allow gamemode to apply GPU optimisations such as overclocks
 ;apply_gpu_optimisations=0
 
-; The device number on the system (usually 0)
+; The DRM device number on the system (usually 0), ie. the number in /sys/class/drm/card0/
 ;gpu_device=0
 
 ; Nvidia specific settings (these are Mhz offsets from the baseline, ie. 0 applies no change)

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -43,9 +43,7 @@ inhibit_screensaver=1
 ; Setting this to the keyphrase "accept-responsibility" will allow gamemode to apply GPU optimisations such as overclocks
 ;apply_gpu_optimisations=0
 
-; You must set these to tell gamemode the Vendor of your graphics card, as well it's device number on the system (usually 0)
-; Vendor must be one of 0x10de (NVIDIA), 0x1002 (AMD) or 0x8086 (Intel)
-;gpu_vendor=0x0000
+; The device number on the system (usually 0)
 ;gpu_device=0
 
 ; Nvidia specific settings (these are Mhz offsets from the baseline, ie. 0 applies no change)


### PR DESCRIPTION
Remove the `gpu_vendor` config variable, this can be auto-detected from the device info in the sysfs.

Also, refactor the testing a little to reflect this and use the `GameModeGPUInfo`  type perhaps more correctly.