### PR TITLE
Add "supervisor" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ Developers can integrate the request directly into an app. Note that none of the
 
 Or, distribute `libgamemodeauto.so` and either add `-lgamemodeauto` to your linker arguments, or add it to an LD\_PRELOAD in a launch script.
 
+### Supervisor support
+Developers can also create apps that manage GameMode on the system, for other processes:
+
+```C
+#include "gamemode_client.h"
+
+	gamemode_request_start_for(gamePID);
+	gamemode_request_end_for(gamePID);
+```
+
+This functionality can also be controlled in the config file in the `supervisor` section.
+
 ---
 ## Contributions
 

--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -171,6 +171,21 @@ static bool get_long_value_hex(const char *value_name, const char *value, long *
 	return true;
 }
 
+/**
+ * Simple strstr scheck
+ * Could be expanded for wildcard or regex
+ */
+static bool config_string_list_contains(const char *needle,
+                                        char haystack[CONFIG_LIST_MAX][CONFIG_VALUE_MAX])
+{
+	for (unsigned int i = 0; i < CONFIG_LIST_MAX && haystack[i][0]; i++) {
+		if (strstr(needle, haystack[i])) {
+			return true;
+		}
+	}
+	return false;
+}
+
 /*
  * Get a string value
  */
@@ -417,12 +432,7 @@ bool config_get_client_whitelisted(GameModeConfig *self, const char *client)
 		 * Check if the value is found in our whitelist
 		 * Currently is a simple strstr check, but could be modified for wildcards etc.
 		 */
-		found = false;
-		for (unsigned int i = 0; i < CONFIG_LIST_MAX && self->values.whitelist[i][0]; i++) {
-			if (strstr(client, self->values.whitelist[i])) {
-				found = true;
-			}
-		}
+		found = config_string_list_contains(client, self->values.whitelist);
 	}
 
 	/* release the lock */
@@ -442,12 +452,7 @@ bool config_get_client_blacklisted(GameModeConfig *self, const char *client)
 	 * Check if the value is found in our whitelist
 	 * Currently is a simple strstr check, but could be modified for wildcards etc.
 	 */
-	bool found = false;
-	for (unsigned int i = 0; i < CONFIG_LIST_MAX && self->values.blacklist[i][0]; i++) {
-		if (strstr(client, self->values.blacklist[i])) {
-			found = true;
-		}
-	}
+	bool found = config_string_list_contains(client, self->values.blacklist);
 
 	/* release the lock */
 	pthread_rwlock_unlock(&self->rwlock);

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -141,3 +141,10 @@ long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_perf_level(GameModeConfig *self);
 long config_get_amd_core_clock_percentage(GameModeConfig *self);
 long config_get_amd_mem_clock_percentage(GameModeConfig *self);
+
+/**
+ * Functions to get supervisor config permissions
+ */
+long config_get_require_supervisor(GameModeConfig *self);
+bool config_get_supervisor_whitelisted(GameModeConfig *self, const char *supervisor);
+bool config_get_supervisor_blacklisted(GameModeConfig *self, const char *supervisor);

--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -165,8 +165,8 @@ static int method_unregister_game_by_pid(sd_bus_message *m, void *userdata,
 /**
  * Handles the QueryStatus D-BUS Method
  */
-static int method_query_status_for(sd_bus_message *m, void *userdata,
-                                   __attribute__((unused)) sd_bus_error *ret_error)
+static int method_query_status_by_pid(sd_bus_message *m, void *userdata,
+                                      __attribute__((unused)) sd_bus_error *ret_error)
 {
 	int callerpid = 0;
 	int gamepid = 0;
@@ -178,7 +178,7 @@ static int method_query_status_for(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	int status = game_mode_context_query_status_for(context, (pid_t)callerpid, (pid_t)gamepid);
+	int status = game_mode_context_query_status_by_pid(context, (pid_t)callerpid, (pid_t)gamepid);
 
 	return sd_bus_reply_method_return(m, "i", status);
 }
@@ -195,7 +195,7 @@ static const sd_bus_vtable gamemode_vtable[] =
 	                SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_METHOD("UnregisterGameByPID", "ii", "i", method_unregister_game_by_pid,
 	                SD_BUS_VTABLE_UNPRIVILEGED),
-	  SD_BUS_METHOD("QueryStatusFor", "ii", "i", method_query_status_for,
+	  SD_BUS_METHOD("QueryStatusByPID", "ii", "i", method_query_status_by_pid,
 	                SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_VTABLE_END };
 

--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -75,9 +75,9 @@ static int method_register_game(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	game_mode_context_register(context, (pid_t)pid);
+	int status = game_mode_context_register(context, (pid_t)pid, (pid_t)pid);
 
-	return sd_bus_reply_method_return(m, "i", 0);
+	return sd_bus_reply_method_return(m, "i", status);
 }
 
 /**
@@ -95,9 +95,9 @@ static int method_unregister_game(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	game_mode_context_unregister(context, (pid_t)pid);
+	int status = game_mode_context_unregister(context, (pid_t)pid, (pid_t)pid);
 
-	return sd_bus_reply_method_return(m, "i", 0);
+	return sd_bus_reply_method_return(m, "i", status);
 }
 
 /**
@@ -115,7 +115,7 @@ static int method_query_status(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	int status = game_mode_context_query_status(context, (pid_t)pid);
+	int status = game_mode_context_query_status(context, (pid_t)pid, (pid_t)pid);
 
 	return sd_bus_reply_method_return(m, "i", status);
 }
@@ -136,7 +136,7 @@ static int method_register_game_by_pid(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	int reply = game_mode_context_register_by_pid(context, (pid_t)callerpid, (pid_t)gamepid);
+	int reply = game_mode_context_register(context, (pid_t)gamepid, (pid_t)callerpid);
 
 	return sd_bus_reply_method_return(m, "i", reply);
 }
@@ -157,7 +157,7 @@ static int method_unregister_game_by_pid(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	int reply = game_mode_context_unregister_by_pid(context, (pid_t)callerpid, (pid_t)gamepid);
+	int reply = game_mode_context_unregister(context, (pid_t)gamepid, (pid_t)callerpid);
 
 	return sd_bus_reply_method_return(m, "i", reply);
 }
@@ -178,7 +178,7 @@ static int method_query_status_by_pid(sd_bus_message *m, void *userdata,
 		return ret;
 	}
 
-	int status = game_mode_context_query_status_by_pid(context, (pid_t)callerpid, (pid_t)gamepid);
+	int status = game_mode_context_query_status(context, (pid_t)gamepid, (pid_t)callerpid);
 
 	return sd_bus_reply_method_return(m, "i", status);
 }

--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -121,6 +121,48 @@ static int method_query_status(sd_bus_message *m, void *userdata,
 }
 
 /**
+ * Handles the RegisterGameByPID D-BUS Method
+ */
+static int method_register_game_by_pid(sd_bus_message *m, void *userdata,
+                                       __attribute__((unused)) sd_bus_error *ret_error)
+{
+	int callerpid = 0;
+	int gamepid = 0;
+	GameModeContext *context = userdata;
+
+	int ret = sd_bus_message_read(m, "ii", &callerpid, &gamepid);
+	if (ret < 0) {
+		LOG_ERROR("Failed to parse input parameters: %s\n", strerror(-ret));
+		return ret;
+	}
+
+	int reply = game_mode_context_register_by_pid(context, (pid_t)callerpid, (pid_t)gamepid);
+
+	return sd_bus_reply_method_return(m, "i", reply);
+}
+
+/**
+ * Handles the UnregisterGameByPID D-BUS Method
+ */
+static int method_unregister_game_by_pid(sd_bus_message *m, void *userdata,
+                                         __attribute__((unused)) sd_bus_error *ret_error)
+{
+	int callerpid = 0;
+	int gamepid = 0;
+	GameModeContext *context = userdata;
+
+	int ret = sd_bus_message_read(m, "ii", &callerpid, &gamepid);
+	if (ret < 0) {
+		LOG_ERROR("Failed to parse input parameters: %s\n", strerror(-ret));
+		return ret;
+	}
+
+	int reply = game_mode_context_unregister_by_pid(context, (pid_t)callerpid, (pid_t)gamepid);
+
+	return sd_bus_reply_method_return(m, "i", reply);
+}
+
+/**
  * D-BUS vtable to dispatch virtual methods
  */
 static const sd_bus_vtable gamemode_vtable[] =
@@ -128,6 +170,10 @@ static const sd_bus_vtable gamemode_vtable[] =
 	  SD_BUS_METHOD("RegisterGame", "i", "i", method_register_game, SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_METHOD("UnregisterGame", "i", "i", method_unregister_game, SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_METHOD("QueryStatus", "i", "i", method_query_status, SD_BUS_VTABLE_UNPRIVILEGED),
+	  SD_BUS_METHOD("RegisterGameByPID", "ii", "i", method_register_game_by_pid,
+	                SD_BUS_VTABLE_UNPRIVILEGED),
+	  SD_BUS_METHOD("UnregisterGameByPID", "ii", "i", method_unregister_game_by_pid,
+	                SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_VTABLE_END };
 
 /**

--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -163,6 +163,27 @@ static int method_unregister_game_by_pid(sd_bus_message *m, void *userdata,
 }
 
 /**
+ * Handles the QueryStatus D-BUS Method
+ */
+static int method_query_status_for(sd_bus_message *m, void *userdata,
+                                   __attribute__((unused)) sd_bus_error *ret_error)
+{
+	int callerpid = 0;
+	int gamepid = 0;
+	GameModeContext *context = userdata;
+
+	int ret = sd_bus_message_read(m, "ii", &callerpid, &gamepid);
+	if (ret < 0) {
+		LOG_ERROR("Failed to parse input parameters: %s\n", strerror(-ret));
+		return ret;
+	}
+
+	int status = game_mode_context_query_status_for(context, (pid_t)callerpid, (pid_t)gamepid);
+
+	return sd_bus_reply_method_return(m, "i", status);
+}
+
+/**
  * D-BUS vtable to dispatch virtual methods
  */
 static const sd_bus_vtable gamemode_vtable[] =
@@ -173,6 +194,8 @@ static const sd_bus_vtable gamemode_vtable[] =
 	  SD_BUS_METHOD("RegisterGameByPID", "ii", "i", method_register_game_by_pid,
 	                SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_METHOD("UnregisterGameByPID", "ii", "i", method_unregister_game_by_pid,
+	                SD_BUS_VTABLE_UNPRIVILEGED),
+	  SD_BUS_METHOD("QueryStatusFor", "ii", "i", method_query_status_for,
 	                SD_BUS_VTABLE_UNPRIVILEGED),
 	  SD_BUS_VTABLE_END };
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -632,6 +632,14 @@ static int run_supervisor_tests(void)
 		supervisortests = -1;
 	}
 
+	// Wait for the child to finish up
+	int wstatus;
+	usleep(100000);
+	while (waitpid(pid, &wstatus, WNOHANG) == 0) {
+		LOG_MSG("...Waiting for child to quit...\n");
+		usleep(100000);
+	}
+
 	if (supervisortests == 0)
 		LOG_MSG(":: Passed\n\n");
 	else

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -599,14 +599,14 @@ static int run_supervisor_tests(void)
 	ret = gamemode_query_status();
 	if(ret != 1)
 	{
-		LOG_ERROR("gamemode_query_status gave unexpected value %d, (expected 1)!\n", ret);
+		LOG_ERROR("gamemode_query_status after start request gave unexpected value %d, (expected 1)!\n", ret);
 		supervisortests = -1;
 	}
 
 	/* Check it's active for the dummy */
 	ret = gamemode_query_status_for(pid);
 	if (ret != 2) {
-		LOG_ERROR("gamemode_query_status_for gave unexpected value %d, (expected 2)!\n", ret);
+		LOG_ERROR("gamemode_query_status_for after start request gave unexpected value %d, (expected 2)!\n", ret);
 		supervisortests = -1;
 	}
 
@@ -614,7 +614,7 @@ static int run_supervisor_tests(void)
 	ret = gamemode_request_end_for(pid);
 	if(ret != 0)
 	{
-		LOG_ERROR("gamemode_request_start_for gave unexpected value %d, (expected 0)!\n", ret);
+		LOG_ERROR("gamemode_request_end_for gave unexpected value %d, (expected 0)!\n", ret);
 		supervisortests = -1;
 	}
 
@@ -622,7 +622,7 @@ static int run_supervisor_tests(void)
 	ret = gamemode_query_status();
 	if(ret != 0)
 	{
-		LOG_ERROR("gamemode_query_status gave unexpected value %d, (expected 0)!\n", ret);
+		LOG_ERROR("gamemode_query_status after end request gave unexpected value %d, (expected 0)!\n", ret);
 		supervisortests = -1;
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -127,12 +127,6 @@ static int run_basic_client_tests(void)
 {
 	LOG_MSG(":: Basic client tests\n");
 
-	/* First verify that gamemode is not currently active on the system
-	 * As well as it being currently installed and queryable
-	 */
-	if (verify_gamemode_initial() != 0)
-		return -1;
-
 	/* Verify that gamemode_request_start correctly start gamemode */
 	if (gamemode_request_start() != 0) {
 		LOG_ERROR("gamemode_request_start failed: %s\n", gamemode_error_string());
@@ -576,6 +570,76 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 	return status;
 }
 
+/* Run a set of tests on the supervisor code */
+static int run_supervisor_tests(void)
+{
+	int supervisortests = 0;
+	int ret = 0;
+
+	LOG_MSG(":: Supervisor tests\n");
+
+	/* Launch an external dummy process we can leave running and request gamemode for it */
+	pid_t pid = fork();
+	if( pid == 0 )
+	{
+		/* Child simply pauses and exits */
+		pause();
+		exit(EXIT_SUCCESS);
+	}
+
+	/* Request gamemode for our dummy process */
+	ret = gamemode_request_start_for(pid);
+	if(ret != 0)
+	{
+		LOG_ERROR("gamemode_request_start_for gave unexpected value %d, (expected 0)!\n", ret);
+		supervisortests = -1;
+	}
+
+	/* Check it's active */
+	ret = gamemode_query_status();
+	if(ret != 1)
+	{
+		LOG_ERROR("gamemode_query_status gave unexpected value %d, (expected 1)!\n", ret);
+		supervisortests = -1;
+	}
+
+	/* Check it's active for the dummy */
+	ret = gamemode_query_status_for(pid);
+	if (ret != 2) {
+		LOG_ERROR("gamemode_query_status_for gave unexpected value %d, (expected 2)!\n", ret);
+		supervisortests = -1;
+	}
+
+	/* request gamemode end for the client */
+	ret = gamemode_request_end_for(pid);
+	if(ret != 0)
+	{
+		LOG_ERROR("gamemode_request_start_for gave unexpected value %d, (expected 0)!\n", ret);
+		supervisortests = -1;
+	}
+
+	/* Verify it's not active */
+	ret = gamemode_query_status();
+	if(ret != 0)
+	{
+		LOG_ERROR("gamemode_query_status gave unexpected value %d, (expected 0)!\n", ret);
+		supervisortests = -1;
+	}
+
+	/* Wake up the child process */
+	if (kill(pid, SIGUSR1) == -1) {
+		LOG_ERROR("failed to send continue signal to other child process: %s\n", strerror(errno));
+		supervisortests = -1;
+	}
+
+	if (supervisortests == 0)
+		LOG_MSG(":: Passed\n\n");
+	else
+		LOG_ERROR(":: Failed!\n");
+
+	return supervisortests;
+}
+
 /**
  * game_mode_run_client_tests runs a set of tests of the client code
  * we simply verify that the client can request the status and recieves the correct results
@@ -595,6 +659,22 @@ int game_mode_run_client_tests()
 
 	LOG_MSG(": Running tests\n\n");
 
+	/* First verify that gamemode is not currently active on the system
+	 * As well as it being currently installed and queryable
+	 */
+	if (verify_gamemode_initial() != 0)
+		return -1;
+
+	/* Controls whether we require a supervisor to actually make requests */
+	/* TODO: This effects all tests below */
+	if( config_get_require_supervisor(config) != 0 )
+	{
+		LOG_ERROR("Tests currently unsupported when require_supervisor is set\n");
+		return -1;
+	}
+
+	/* TODO: Also check blacklist/whitelist values as these may mess up the tests below */
+
 	/* Run the basic tests */
 	if (run_basic_client_tests() != 0)
 		status = -1;
@@ -605,6 +685,10 @@ int game_mode_run_client_tests()
 
 	/* Check gamemoderun and the reaper thread work */
 	if (run_gamemoderun_and_reaper_tests(config) != 0)
+		status = -1;
+
+	/* Run the supervisor tests */
+	if (run_supervisor_tests() != 0)
 		status = -1;
 
 	if (status != 0) {

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -580,8 +580,7 @@ static int run_supervisor_tests(void)
 
 	/* Launch an external dummy process we can leave running and request gamemode for it */
 	pid_t pid = fork();
-	if( pid == 0 )
-	{
+	if (pid == 0) {
 		/* Child simply pauses and exits */
 		pause();
 		exit(EXIT_SUCCESS);
@@ -589,40 +588,43 @@ static int run_supervisor_tests(void)
 
 	/* Request gamemode for our dummy process */
 	ret = gamemode_request_start_for(pid);
-	if(ret != 0)
-	{
+	if (ret != 0) {
 		LOG_ERROR("gamemode_request_start_for gave unexpected value %d, (expected 0)!\n", ret);
 		supervisortests = -1;
 	}
 
 	/* Check it's active */
 	ret = gamemode_query_status();
-	if(ret != 1)
-	{
-		LOG_ERROR("gamemode_query_status after start request gave unexpected value %d, (expected 1)!\n", ret);
+	if (ret != 1) {
+		LOG_ERROR(
+		    "gamemode_query_status after start request gave unexpected value %d, (expected 1)!\n",
+		    ret);
 		supervisortests = -1;
 	}
 
 	/* Check it's active for the dummy */
 	ret = gamemode_query_status_for(pid);
 	if (ret != 2) {
-		LOG_ERROR("gamemode_query_status_for after start request gave unexpected value %d, (expected 2)!\n", ret);
+		LOG_ERROR(
+		    "gamemode_query_status_for after start request gave unexpected value %d, (expected "
+		    "2)!\n",
+		    ret);
 		supervisortests = -1;
 	}
 
 	/* request gamemode end for the client */
 	ret = gamemode_request_end_for(pid);
-	if(ret != 0)
-	{
+	if (ret != 0) {
 		LOG_ERROR("gamemode_request_end_for gave unexpected value %d, (expected 0)!\n", ret);
 		supervisortests = -1;
 	}
 
 	/* Verify it's not active */
 	ret = gamemode_query_status();
-	if(ret != 0)
-	{
-		LOG_ERROR("gamemode_query_status after end request gave unexpected value %d, (expected 0)!\n", ret);
+	if (ret != 0) {
+		LOG_ERROR(
+		    "gamemode_query_status after end request gave unexpected value %d, (expected 0)!\n",
+		    ret);
 		supervisortests = -1;
 	}
 
@@ -675,8 +677,7 @@ int game_mode_run_client_tests()
 
 	/* Controls whether we require a supervisor to actually make requests */
 	/* TODO: This effects all tests below */
-	if( config_get_require_supervisor(config) != 0 )
-	{
+	if (config_get_require_supervisor(config) != 0) {
 		LOG_ERROR("Tests currently unsupported when require_supervisor is set\n");
 		return -1;
 	}

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -590,6 +590,8 @@ static int run_supervisor_tests(void)
 	ret = gamemode_request_start_for(pid);
 	if (ret != 0) {
 		LOG_ERROR("gamemode_request_start_for gave unexpected value %d, (expected 0)!\n", ret);
+		if (ret == -1)
+			LOG_ERROR("GameMode error string: %s!\n", gamemode_error_string());
 		supervisortests = -1;
 	}
 
@@ -599,6 +601,8 @@ static int run_supervisor_tests(void)
 		LOG_ERROR(
 		    "gamemode_query_status after start request gave unexpected value %d, (expected 1)!\n",
 		    ret);
+		if (ret == -1)
+			LOG_ERROR("GameMode error string: %s!\n", gamemode_error_string());
 		supervisortests = -1;
 	}
 
@@ -609,6 +613,8 @@ static int run_supervisor_tests(void)
 		    "gamemode_query_status_for after start request gave unexpected value %d, (expected "
 		    "2)!\n",
 		    ret);
+		if (ret == -1)
+			LOG_ERROR("GameMode error string: %s!\n", gamemode_error_string());
 		supervisortests = -1;
 	}
 
@@ -616,6 +622,8 @@ static int run_supervisor_tests(void)
 	ret = gamemode_request_end_for(pid);
 	if (ret != 0) {
 		LOG_ERROR("gamemode_request_end_for gave unexpected value %d, (expected 0)!\n", ret);
+		if (ret == -1)
+			LOG_ERROR("GameMode error string: %s!\n", gamemode_error_string());
 		supervisortests = -1;
 	}
 
@@ -625,6 +633,8 @@ static int run_supervisor_tests(void)
 		LOG_ERROR(
 		    "gamemode_query_status after end request gave unexpected value %d, (expected 0)!\n",
 		    ret);
+		if (ret == -1)
+			LOG_ERROR("GameMode error string: %s!\n", gamemode_error_string());
 		supervisortests = -1;
 	}
 

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -361,6 +361,8 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 			free(executable);
 			return -2;
 		}
+	} else if (config_get_require_supervisor(self->config)) {
+		LOG_ERROR("Direct request made but require_supervisor was set, rejecting request!\n");
 	}
 
 	/* Cap the total number of active clients */
@@ -463,6 +465,8 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 		}
 
 		free(executable);
+	} else if (config_get_require_supervisor(self->config)) {
+		LOG_ERROR("Direct request made but require_supervisor was set, rejecting request!\n");
 	}
 
 	/* Requires locking. */

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -571,7 +571,7 @@ error_cleanup:
 /**
  * Request status on behalf of caller
  */
-int game_mode_context_query_status_for(GameModeContext *self, pid_t callerpid, pid_t gamepid)
+int game_mode_context_query_status_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid)
 {
 	int status = 0;
 

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -503,6 +503,28 @@ int game_mode_context_query_status(GameModeContext *self, pid_t client)
 }
 
 /**
+ * Stub to register on behalf of caller
+ */
+int game_mode_context_register_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid)
+{
+	(void)self;
+	(void)callerpid;
+	(void)gamepid;
+	return 0;
+}
+
+/**
+ * Stub to unregister on behalf of caller
+ */
+int game_mode_context_unregister_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid)
+{
+	(void)self;
+	(void)callerpid;
+	(void)gamepid;
+	return 0;
+}
+
+/**
  * Construct a new GameModeClient for the given process ID
  *
  * This is deliberately OOM safe

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -363,6 +363,7 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 		}
 	} else if (config_get_require_supervisor(self->config)) {
 		LOG_ERROR("Direct request made but require_supervisor was set, rejecting request!\n");
+		return -2;
 	}
 
 	/* Cap the total number of active clients */
@@ -467,6 +468,7 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 		free(executable);
 	} else if (config_get_require_supervisor(self->config)) {
 		LOG_ERROR("Direct request made but require_supervisor was set, rejecting request!\n");
+		return -2;
 	}
 
 	/* Requires locking. */

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -429,7 +429,7 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 	/* Apply io priorities */
 	game_mode_apply_ioprio(self, client);
 
-	return true;
+	return 0;
 
 error_cleanup:
 	if (errno != 0)
@@ -511,7 +511,7 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 		game_mode_context_leave(self);
 	}
 
-	return true;
+	return 0;
 }
 
 int game_mode_context_query_status(GameModeContext *self, pid_t client, pid_t requester)

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -503,7 +503,7 @@ int game_mode_context_query_status(GameModeContext *self, pid_t client)
 }
 
 /**
- * Stub to register on behalf of caller
+ * Register on behalf of caller
  * TODO: long config_get_require_supervisor(GameModeConfig *self);
  */
 int game_mode_context_register_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid)
@@ -537,7 +537,7 @@ error_cleanup:
 }
 
 /**
- * Stub to unregister on behalf of caller
+ * Unregister on behalf of caller
  */
 int game_mode_context_unregister_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid)
 {

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -90,6 +90,28 @@ bool game_mode_context_unregister(GameModeContext *self, pid_t pid);
 int game_mode_context_query_status(GameModeContext *self, pid_t pid);
 
 /**
+ * Register a new game client with the context on behalf of another process
+ *
+ * @param callerpid Process ID for the remote client making the request
+ * @param gamepid Process ID for the process to be registered
+ * @returns 0 if the request was accepted and the client could be registered
+ *          -1 if the request was accepted but the client could not be registered
+ *          -2 if the request was rejected
+ */
+int game_mode_context_register_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
+
+/**
+ * Unregister an existing remote game client from the context on behalf of another process
+ *
+ * @param callerpid Process ID for the remote client making the request
+ * @param gamepid Process ID for the process to be registered
+ * @returns 0 if the request was accepted and the client existed
+ *          -1 if the request was accepted but the client did not exist
+ *          -2 if the request was rejected
+ */
+int game_mode_context_unregister_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
+
+/**
  * Query the config of a gamemode context
  *
  * @param context A gamemode context

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -112,6 +112,17 @@ int game_mode_context_register_by_pid(GameModeContext *self, pid_t callerpid, pi
 int game_mode_context_unregister_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
 
 /**
+ * Query the current status of gamemode for another process
+ *
+ * @param pid Process ID for the remote client
+ * @returns Positive if gamemode is active
+ *          1 if gamemode is active but the client is not registered
+ *          2 if gamemode is active and the client is registered
+ *          -2 if this supervisor was rejected
+ */
+int game_mode_context_query_status_for(GameModeContext *self, pid_t callerpid, pid_t gamepid);
+
+/**
  * Query the config of a gamemode context
  *
  * @param context A gamemode context

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -120,7 +120,7 @@ int game_mode_context_unregister_by_pid(GameModeContext *self, pid_t callerpid, 
  *          2 if gamemode is active and the client is registered
  *          -2 if this supervisor was rejected
  */
-int game_mode_context_query_status_for(GameModeContext *self, pid_t callerpid, pid_t gamepid);
+int game_mode_context_query_status_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
 
 /**
  * Query the config of a gamemode context

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -67,17 +67,23 @@ void game_mode_context_destroy(GameModeContext *self);
  * Register a new game client with the context
  *
  * @param pid Process ID for the remote client
- * @returns True if the new client could be registered
+ * @param requester Process ID for the remote requestor
+ * @returns 0 if the request was accepted and the client could be registered
+ *          -1 if the request was accepted but the client could not be registered
+ *          -2 if the request was rejected
  */
-bool game_mode_context_register(GameModeContext *self, pid_t pid);
+int game_mode_context_register(GameModeContext *self, pid_t pid, pid_t requester);
 
 /**
  * Unregister an existing remote game client from the context
  *
  * @param pid Process ID for the remote client
- * @returns True if the client was removed, and existed.
+ * @param requester Process ID for the remote requestor
+ * @returns 0 if the request was accepted and the client existed
+ *          -1 if the request was accepted but the client did not exist
+ *          -2 if the request was rejected
  */
-bool game_mode_context_unregister(GameModeContext *self, pid_t pid);
+int game_mode_context_unregister(GameModeContext *self, pid_t pid, pid_t requester);
 
 /**
  * Query the current status of gamemode
@@ -86,41 +92,9 @@ bool game_mode_context_unregister(GameModeContext *self, pid_t pid);
  * @returns Positive if gamemode is active
  *          1 if gamemode is active but the client is not registered
  *          2 if gamemode is active and the client is registered
+ *          -2 if this requester was rejected
  */
-int game_mode_context_query_status(GameModeContext *self, pid_t pid);
-
-/**
- * Register a new game client with the context on behalf of another process
- *
- * @param callerpid Process ID for the remote client making the request
- * @param gamepid Process ID for the process to be registered
- * @returns 0 if the request was accepted and the client could be registered
- *          -1 if the request was accepted but the client could not be registered
- *          -2 if the request was rejected
- */
-int game_mode_context_register_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
-
-/**
- * Unregister an existing remote game client from the context on behalf of another process
- *
- * @param callerpid Process ID for the remote client making the request
- * @param gamepid Process ID for the process to be registered
- * @returns 0 if the request was accepted and the client existed
- *          -1 if the request was accepted but the client did not exist
- *          -2 if the request was rejected
- */
-int game_mode_context_unregister_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
-
-/**
- * Query the current status of gamemode for another process
- *
- * @param pid Process ID for the remote client
- * @returns Positive if gamemode is active
- *          1 if gamemode is active but the client is not registered
- *          2 if gamemode is active and the client is registered
- *          -2 if this supervisor was rejected
- */
-int game_mode_context_query_status_by_pid(GameModeContext *self, pid_t callerpid, pid_t gamepid);
+int game_mode_context_query_status(GameModeContext *self, pid_t pid, pid_t requester);
 
 /**
  * Query the config of a gamemode context

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -61,6 +61,16 @@ inhibit_screensaver=1
 ;amd_core_clock_percentage=0
 ;amd_mem_clock_percentage=0
 
+[supervisor]
+; This section controls the new gamemode functions gamemode_request_start_for and gamemode_request_end_for
+; The whilelist and blacklist control which supervisor programs are allowed to make the above requests
+;supervisor_whitelist=
+;supervisor_blacklist=
+
+; In case you want to allow a supervisor to take full control of gamemode, this option can be set
+; This will only allow gamemode clients to be registered by using the above functions by a supervisor client
+;require_supervisor=0
+
 [custom]
 ; Custom scripts (executed using the shell) when gamemode starts and ends
 ;start=notify-send "GameMode started"

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -124,3 +124,9 @@ extern int real_gamemode_register_end_for(pid_t pid)
 {
 	return gamemode_request("UnregisterGameByPID", pid);
 }
+
+// Wrapper to call QueryStatusFor
+extern int real_gamemode_query_status_for(pid_t pid)
+{
+	return gamemode_request("QueryStatusFor", pid);
+}

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -43,7 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 static char error_string[512] = { 0 };
 
 // Simple requestor function for a gamemode
-static int gamemode_request(const char *function)
+static int gamemode_request(const char *function, int arg)
 {
 	sd_bus_message *msg = NULL;
 	sd_bus *bus = NULL;
@@ -66,8 +66,9 @@ static int gamemode_request(const char *function)
 		                         function,
 		                         NULL,
 		                         &msg,
-		                         "i",
-		                         getpid());
+		                         arg ? "ii" : "i",
+		                         getpid(),
+		                         arg);
 		if (ret < 0) {
 			snprintf(error_string,
 			         sizeof(error_string),
@@ -97,17 +98,29 @@ extern const char *real_gamemode_error_string(void)
 // Wrapper to call RegisterGame
 extern int real_gamemode_request_start(void)
 {
-	return gamemode_request("RegisterGame");
+	return gamemode_request("RegisterGame", 0);
 }
 
 // Wrapper to call UnregisterGame
 extern int real_gamemode_request_end(void)
 {
-	return gamemode_request("UnregisterGame");
+	return gamemode_request("UnregisterGame", 0);
 }
 
-// Wrapper to call UnregisterGame
+// Wrapper to call QueryStatus
 extern int real_gamemode_query_status(void)
 {
-	return gamemode_request("QueryStatus");
+	return gamemode_request("QueryStatus", 0);
+}
+
+// Wrapper to call RegisterGameByPID
+extern int real_gamemode_register_start_for(pid_t pid)
+{
+	return gamemode_request("RegisterGameByPID", pid);
+}
+
+// Wrapper to call UnregisterGameByPID
+extern int real_gamemode_register_end_for(pid_t pid)
+{
+	return gamemode_request("UnregisterGameByPID", pid);
 }

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -114,13 +114,13 @@ extern int real_gamemode_query_status(void)
 }
 
 // Wrapper to call RegisterGameByPID
-extern int real_gamemode_register_start_for(pid_t pid)
+extern int real_gamemode_request_start_for(pid_t pid)
 {
 	return gamemode_request("RegisterGameByPID", pid);
 }
 
 // Wrapper to call UnregisterGameByPID
-extern int real_gamemode_register_end_for(pid_t pid)
+extern int real_gamemode_request_end_for(pid_t pid)
 {
 	return gamemode_request("UnregisterGameByPID", pid);
 }

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -125,8 +125,8 @@ extern int real_gamemode_register_end_for(pid_t pid)
 	return gamemode_request("UnregisterGameByPID", pid);
 }
 
-// Wrapper to call QueryStatusFor
+// Wrapper to call QueryStatusByPID
 extern int real_gamemode_query_status_for(pid_t pid)
 {
-	return gamemode_request("QueryStatusFor", pid);
+	return gamemode_request("QueryStatusByPID", pid);
 }

--- a/lib/gamemode_client.h
+++ b/lib/gamemode_client.h
@@ -72,16 +72,14 @@ static char internal_gamemode_client_error_string[512] = { 0 };
 static volatile int internal_libgamemode_loaded = 1;
 
 /* Typedefs for the functions to load */
-typedef int (*internal_gamemode_request_start)(void);
-typedef int (*internal_gamemode_request_end)(void);
-typedef int (*internal_gamemode_query_status)(void);
-typedef const char *(*internal_gamemode_error_string)(void);
+typedef int (*api_call_return_int)(void);
+typedef const char *(*api_call_return_cstring)(void);
 
 /* Storage for functors */
-static internal_gamemode_request_start REAL_internal_gamemode_request_start = NULL;
-static internal_gamemode_request_end REAL_internal_gamemode_request_end = NULL;
-static internal_gamemode_query_status REAL_internal_gamemode_query_status = NULL;
-static internal_gamemode_error_string REAL_internal_gamemode_error_string = NULL;
+static api_call_return_int REAL_internal_gamemode_request_start = NULL;
+static api_call_return_int REAL_internal_gamemode_request_end = NULL;
+static api_call_return_int REAL_internal_gamemode_query_status = NULL;
+static api_call_return_cstring REAL_internal_gamemode_error_string = NULL;
 
 /**
  * Internal helper to perform the symbol binding safely.

--- a/lib/gamemode_client.h
+++ b/lib/gamemode_client.h
@@ -101,10 +101,8 @@ static api_call_pid_return_int REAL_internal_gamemode_request_end_for = NULL;
  *
  * Returns 0 on success and -1 on failure
  */
-__attribute__((always_inline)) static inline int internal_bind_libgamemode_symbol(void *handle,
-                                                                                  const char *name,
-                                                                                  void **out_func,
-                                                                                  size_t func_size)
+__attribute__((always_inline)) static inline int internal_bind_libgamemode_symbol(
+    void *handle, const char *name, void **out_func, size_t func_size, bool required)
 {
 	void *symbol_lookup = NULL;
 	char *dl_error = NULL;
@@ -112,7 +110,7 @@ __attribute__((always_inline)) static inline int internal_bind_libgamemode_symbo
 	/* Safely look up the symbol */
 	symbol_lookup = dlsym(handle, name);
 	dl_error = dlerror();
-	if (dl_error || !symbol_lookup) {
+	if (required && (dl_error || !symbol_lookup)) {
 		snprintf(internal_gamemode_client_error_string,
 		         sizeof(internal_gamemode_client_error_string),
 		         "dlsym failed - %s",
@@ -196,8 +194,8 @@ __attribute__((always_inline)) static inline int internal_load_libgamemode(void)
 		if (internal_bind_libgamemode_symbol(libgamemode,
 		                                     binder->name,
 		                                     binder->functor,
-		                                     binder->func_size) != 0 &&
-		    binder->required) {
+		                                     binder->func_size,
+		                                     binder->required)) {
 			internal_libgamemode_loaded = -1;
 			return -1;
 		};


### PR DESCRIPTION
This adds support for a "supervisor" type process to request gamemode for other processes.

**External**
- `gamemode_request_start_for` to request gamemode starts for another process
- `gamemode_request_end_for` to request gamemode ends for another process
- Bugfix: when non-required functions (like the above) don't exist, we now safely fail, instead of outright bailing, see 852f096

These two client functions are a simple noop when an older daemon lib is installed.

**Config**
- `supervisor` config section for the below settings
- `require_supervisor` can be used to restrict all gamemode registrations to just supervisor functions
- `supervisor_whitelist` to whitelist specific supervisor programs (if this exists, anything not matching is rejected)
- `supervisor_blacklist` to blacklist specific supervisor programs (anything matching is rejected)

**Internal**
- `config_string_list_contains` checks if a string list contains a substring match
- dbus methods `RegisterGameByPID` and `UnregisterGameByPID` to assist the new client APIs

**Tests**
New test coverage for supervisor functionality. Pass looks like this locally for me:
```
:: Supervisor tests
:: Passed
```
Note: When `require_supervisor` is set the current tests will bail out, for now. A small test refactor will be needed to get that working.

