### PR TITLE
Assorted small bug fixes

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -71,6 +71,7 @@ struct GameModeConfig {
 		char whitelist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		char blacklist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 
+		long script_timeout;
 		char startscripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		char endscripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 
@@ -278,6 +279,8 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = append_value_to_list(name, value, self->values.startscripts);
 		} else if (strcmp(name, "end") == 0) {
 			valid = append_value_to_list(name, value, self->values.endscripts);
+		} else if (strcmp(name, "script_timeout") == 0) {
+			valid = get_long_value(name, value, &self->values.script_timeout);
 		}
 	}
 
@@ -330,6 +333,7 @@ static void load_config_files(GameModeConfig *self)
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = -1; /* 0 is a valid device ID so use -1 to indicate no value */
 	self->values.nv_perf_level = -1;
+	self->values.script_timeout = 10; /* Default to 10 seconds for scripts */
 
 	/*
 	 * Locations to load, in order
@@ -505,6 +509,11 @@ void config_get_gamemode_end_scripts(GameModeConfig *self,
 {
 	memcpy_locked_config(self, scripts, self->values.endscripts, sizeof(self->values.startscripts));
 }
+
+/*
+ * Get the script timemout value
+ */
+DEFINE_CONFIG_GET(script_timeout)
 
 /*
  * Get the chosen default governor

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -106,6 +106,11 @@ void config_get_gamemode_end_scripts(GameModeConfig *self,
                                      char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX]);
 
 /*
+ * Get the script timout value
+ */
+long config_get_script_timeout(GameModeConfig *self);
+
+/*
  * Get the chosen default governor
  */
 void config_get_default_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);

--- a/daemon/external-helper.c
+++ b/daemon/external-helper.c
@@ -40,10 +40,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <time.h>
 #include <unistd.h>
 
+static const int default_timout = 5;
+
 /**
  * Call an external process
  */
-int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX])
+int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX], int tsec)
 {
 	pid_t p;
 	int status = 0;
@@ -52,6 +54,11 @@ int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFF
 	if (pipe(pipes) == -1) {
 		LOG_ERROR("Could not create pipe: %s!\n", strerror(errno));
 		return -1;
+	}
+
+	/* Set the default timeout */
+	if (tsec == -1) {
+		tsec = default_timout;
 	}
 
 	/* set up our signaling for the child and the timout */
@@ -88,7 +95,8 @@ int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFF
 
 	/* Set up the timout */
 	struct timespec timeout;
-	timeout.tv_sec = 5; /* Magic timeout value of 5s for now - should be sane for most commands */
+	timeout.tv_sec = tsec; /* Magic timeout value of 5s for now - should be sane for most commands
+	                        */
 	timeout.tv_nsec = 0;
 
 	/* Wait for the child to finish up with a timout */

--- a/daemon/external-helper.h
+++ b/daemon/external-helper.h
@@ -34,7 +34,4 @@ POSSIBILITY OF SUCH DAMAGE.
 #define EXTERNAL_BUFFER_MAX 1024
 
 /* Run an external process and capture the return value */
-int run_external_process(const char *const *exec_args);
-
-/* Run an external process and capture the return value as well as output */
-int run_external_process_get_output(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);
+int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);

--- a/daemon/external-helper.h
+++ b/daemon/external-helper.h
@@ -34,4 +34,4 @@ POSSIBILITY OF SUCH DAMAGE.
 #define EXTERNAL_BUFFER_MAX 1024
 
 /* Run an external process and capture the return value */
-int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);
+int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX], int tsec);

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -229,7 +229,7 @@ int game_mode_apply_gpu(const GameModeGPUInfo *info, bool apply)
 		NULL,
 	};
 
-	if (run_external_process(exec_args) != 0) {
+	if (run_external_process(exec_args, NULL) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could not apply optimisations!\n");
 		return -1;
 	}
@@ -262,7 +262,7 @@ int game_mode_get_gpu(GameModeGPUInfo *info)
 	};
 
 	char buffer[EXTERNAL_BUFFER_MAX] = { 0 };
-	if (run_external_process_get_output(exec_args, buffer) != 0) {
+	if (run_external_process(exec_args, buffer) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could get values!\n");
 		return -1;
 	}

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -229,7 +229,7 @@ int game_mode_apply_gpu(const GameModeGPUInfo *info, bool apply)
 		NULL,
 	};
 
-	if (run_external_process(exec_args, NULL) != 0) {
+	if (run_external_process(exec_args, NULL, -1) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could not apply optimisations!\n");
 		return -1;
 	}
@@ -262,7 +262,7 @@ int game_mode_get_gpu(GameModeGPUInfo *info)
 	};
 
 	char buffer[EXTERNAL_BUFFER_MAX] = { 0 };
-	if (run_external_process(exec_args, buffer) != 0) {
+	if (run_external_process(exec_args, buffer, -1) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could get values!\n");
 		return -1;
 	}

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -360,6 +360,7 @@ static int run_cpu_governor_tests(struct GameModeConfig *config)
 static int run_custom_scripts_tests(struct GameModeConfig *config)
 {
 	int scriptstatus = 0;
+	long timeout = config_get_script_timeout(config);
 
 	/* Grab and test the start scripts */
 	char startscripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
@@ -372,7 +373,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
-			int ret = run_external_process(args, NULL, 10);
+			int ret = run_external_process(args, NULL, (int)timeout);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -395,7 +396,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
-			int ret = run_external_process(args, NULL, 10);
+			int ret = run_external_process(args, NULL, (int)timeout);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -372,7 +372,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
-			int ret = run_external_process(args, NULL);
+			int ret = run_external_process(args, NULL, 10);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -395,7 +395,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
-			int ret = run_external_process(args, NULL);
+			int ret = run_external_process(args, NULL, 10);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 
 #include "daemon_config.h"
+#include "external-helper.h"
 #include "gamemode_client.h"
 #include "governors-query.h"
 #include "gpu-control.h"
@@ -370,7 +371,8 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 		while (*startscripts[i] != '\0' && i < CONFIG_LIST_MAX) {
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
-			int ret = system(startscripts[i]);
+			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
+			int ret = run_external_process(args);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -392,7 +394,8 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 		while (*endscripts[i] != '\0' && i < CONFIG_LIST_MAX) {
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
-			int ret = system(endscripts[i]);
+			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
+			int ret = run_external_process(args);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -201,8 +201,8 @@ static int run_dual_client_tests(void)
 	/* Parent process */
 	/* None of these should early-out as we need to clean up the child */
 
-	/* Give the child a chance to reqeust gamemode */
-	usleep(1000);
+	/* Give the child a chance to request gamemode */
+	usleep(10000);
 
 	/* Check that when we request gamemode, it replies that the other client is connected */
 	if (verify_other_client_connected() != 0)

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -372,7 +372,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
-			int ret = run_external_process(args);
+			int ret = run_external_process(args, NULL);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -395,7 +395,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
-			int ret = run_external_process(args);
+			int ret = run_external_process(args, NULL);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -319,12 +319,11 @@ static int run_cpu_governor_tests(struct GameModeConfig *config)
 		strcpy(desiredgov, "performance");
 
 	char defaultgov[CONFIG_VALUE_MAX] = { 0 };
-	config_get_default_governor(config, defaultgov);
 
-	if (desiredgov[0] == '\0') {
+	if (defaultgov[0] == '\0') {
 		const char *currentgov = get_gov_state();
 		if (currentgov) {
-			strncpy(desiredgov, currentgov, CONFIG_VALUE_MAX);
+			strncpy(defaultgov, currentgov, CONFIG_VALUE_MAX);
 		} else {
 			LOG_ERROR(
 			    "Could not get current CPU governor state, this indicates an error! See rest "

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -93,6 +93,7 @@ static void *game_mode_context_reaper(void *userdata);
 static void game_mode_context_enter(GameModeContext *self);
 static void game_mode_context_leave(GameModeContext *self);
 static char *game_mode_context_find_exe(pid_t pid);
+static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX]);
 
 void game_mode_context_init(GameModeContext *self)
 {
@@ -208,17 +209,7 @@ static void game_mode_context_enter(GameModeContext *self)
 	char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 	memset(scripts, 0, sizeof(scripts));
 	config_get_gamemode_start_scripts(self->config, scripts);
-
-	unsigned int i = 0;
-	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
-		LOG_MSG("Executing script [%s]\n", scripts[i]);
-		int err;
-		if ((err = system(scripts[i])) != 0) {
-			/* Log the failure, but this is not fatal */
-			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
-		}
-		i++;
-	}
+	game_mode_execute_scripts(scripts);
 }
 
 /**
@@ -261,17 +252,7 @@ static void game_mode_context_leave(GameModeContext *self)
 	char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 	memset(scripts, 0, sizeof(scripts));
 	config_get_gamemode_end_scripts(self->config, scripts);
-
-	unsigned int i = 0;
-	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
-		LOG_MSG("Executing script [%s]\n", scripts[i]);
-		int err;
-		if ((err = system(scripts[i])) != 0) {
-			/* Log the failure, but this is not fatal */
-			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
-		}
-		i++;
-	}
+	game_mode_execute_scripts(scripts);
 }
 
 /**
@@ -702,4 +683,19 @@ fail:
 	if (errno != 0) // otherwise a proper message was logged before
 		LOG_ERROR("Unable to find executable for PID %d: %s\n", pid, strerror(errno));
 	return NULL;
+}
+
+/* Executes a set of scripts */
+static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX])
+{
+	unsigned int i = 0;
+	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
+		LOG_MSG("Executing script [%s]\n", scripts[i]);
+		int err;
+		if ((err = system(scripts[i])) != 0) {
+			/* Log the failure, but this is not fatal */
+			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
+		}
+		i++;
+	}
 }

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -692,7 +692,8 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
 		LOG_MSG("Executing script [%s]\n", scripts[i]);
 		int err;
-		if ((err = system(scripts[i])) != 0) {
+		const char *args[] = { "/bin/sh", "-c", scripts[i], NULL };
+		if ((err = run_external_process(args)) != 0) {
 			/* Log the failure, but this is not fatal */
 			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
 		}

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -189,7 +189,7 @@ static void game_mode_context_enter(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", desiredGov);
-		if (run_external_process(exec_args) != 0) {
+		if (run_external_process(exec_args, NULL) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 			/* if the set fails, clear the initial mode so we don't try and reset it back and fail
 			 * again, presumably */
@@ -242,7 +242,7 @@ static void game_mode_context_leave(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", gov_mode);
-		if (run_external_process(exec_args) != 0) {
+		if (run_external_process(exec_args, NULL) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 		}
 
@@ -693,7 +693,7 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 		LOG_MSG("Executing script [%s]\n", scripts[i]);
 		int err;
 		const char *args[] = { "/bin/sh", "-c", scripts[i], NULL };
-		if ((err = run_external_process(args)) != 0) {
+		if ((err = run_external_process(args, NULL)) != 0) {
 			/* Log the failure, but this is not fatal */
 			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
 		}

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -189,7 +189,7 @@ static void game_mode_context_enter(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", desiredGov);
-		if (run_external_process(exec_args, NULL) != 0) {
+		if (run_external_process(exec_args, NULL, -1) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 			/* if the set fails, clear the initial mode so we don't try and reset it back and fail
 			 * again, presumably */
@@ -242,7 +242,7 @@ static void game_mode_context_leave(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", gov_mode);
-		if (run_external_process(exec_args, NULL) != 0) {
+		if (run_external_process(exec_args, NULL, -1) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 		}
 
@@ -693,7 +693,7 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 		LOG_MSG("Executing script [%s]\n", scripts[i]);
 		int err;
 		const char *args[] = { "/bin/sh", "-c", scripts[i], NULL };
-		if ((err = run_external_process(args, NULL)) != 0) {
+		if ((err = run_external_process(args, NULL, 10)) != 0) {
 			/* Log the failure, but this is not fatal */
 			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
 		}

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -79,7 +79,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_CORE_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process(exec_args_core, buf) != 0) {
+	if (run_external_process(exec_args_core, buf, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -98,7 +98,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_MEM_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process(exec_args_mem, buf) != 0) {
+	if (run_external_process(exec_args_mem, buf, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -145,7 +145,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->core);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", core_arg, NULL };
-	if (run_external_process(exec_args_core, NULL) != 0) {
+	if (run_external_process(exec_args_core, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", core_arg);
 		return -1;
 	}
@@ -160,7 +160,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->mem);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", mem_arg, NULL };
-	if (run_external_process(exec_args_mem, NULL) != 0) {
+	if (run_external_process(exec_args_mem, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", mem_arg);
 		return -1;
 	}

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -79,7 +79,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_CORE_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process_get_output(exec_args_core, buf) != 0) {
+	if (run_external_process(exec_args_core, buf) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -98,7 +98,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_MEM_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process_get_output(exec_args_mem, buf) != 0) {
+	if (run_external_process(exec_args_mem, buf) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -145,7 +145,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->core);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", core_arg, NULL };
-	if (run_external_process(exec_args_core) != 0) {
+	if (run_external_process(exec_args_core, NULL) != 0) {
 		LOG_ERROR("Failed to set %s!\n", core_arg);
 		return -1;
 	}
@@ -160,7 +160,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->mem);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", mem_arg, NULL };
-	if (run_external_process(exec_args_mem) != 0) {
+	if (run_external_process(exec_args_mem, NULL) != 0) {
 		LOG_ERROR("Failed to set %s!\n", mem_arg);
 		return -1;
 	}

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -47,6 +47,8 @@ static int gamemode_request(const char *function, int arg)
 {
 	sd_bus_message *msg = NULL;
 	sd_bus *bus = NULL;
+	sd_bus_error err;
+	memset(&err, 0, sizeof(err));
 
 	int result = -1;
 
@@ -64,7 +66,7 @@ static int gamemode_request(const char *function, int arg)
 		                         "/com/feralinteractive/GameMode",
 		                         "com.feralinteractive.GameMode",
 		                         function,
-		                         NULL,
+		                         &err,
 		                         &msg,
 		                         arg ? "ii" : "i",
 		                         getpid(),
@@ -72,7 +74,13 @@ static int gamemode_request(const char *function, int arg)
 		if (ret < 0) {
 			snprintf(error_string,
 			         sizeof(error_string),
-			         "Could not call method on bus: %s",
+			         "Could not call method %s on com.feralinteractive.GameMode\n"
+			         "\t%s\n"
+			         "\t%s\n"
+			         "\t%s\n",
+			         function,
+			         err.name,
+			         err.message,
 			         strerror(-ret));
 		} else {
 			// Read the reply


### PR DESCRIPTION
I've had these sitting for a bit. Fixes include:

* Implement timeout for external script commands, controlled by `script_timeout`
* Add output for failed external commands
* Run custom scripts last always so the internal optimizations are always applied and removed timely
* Tests now wait for a bit before running, in case a process still has gamemode and will be reaped
* Log the actual dbus errors in the client to help debugging
* Make the governor test actually check the old governor first