### PR TITLE
GPU performance level/mode pinning

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -92,8 +92,7 @@ struct GameModeConfig {
 		long nv_core_clock_mhz_offset;
 		long nv_mem_clock_mhz_offset;
 		long nv_perf_level;
-		long amd_core_clock_percentage;
-		long amd_mem_clock_percentage;
+		char amd_performance_level[CONFIG_VALUE_MAX];
 
 		long require_supervisor;
 		char supervisor_whitelist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
@@ -259,10 +258,8 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = get_long_value(name, value, &self->values.nv_mem_clock_mhz_offset);
 		} else if (strcmp(name, "nv_perf_level") == 0) {
 			valid = get_long_value(name, value, &self->values.nv_perf_level);
-		} else if (strcmp(name, "amd_core_clock_percentage") == 0) {
-			valid = get_long_value(name, value, &self->values.amd_core_clock_percentage);
-		} else if (strcmp(name, "amd_mem_clock_percentage") == 0) {
-			valid = get_long_value(name, value, &self->values.amd_mem_clock_percentage);
+		} else if (strcmp(name, "amd_performance_level") == 0) {
+			valid = get_string_value(value, self->values.amd_performance_level);
 		}
 	} else if (strcmp(section, "supervisor") == 0) {
 		/* Supervisor subsection */
@@ -585,8 +582,14 @@ DEFINE_CONFIG_GET(gpu_device)
 DEFINE_CONFIG_GET(nv_core_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_mem_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_perf_level)
-DEFINE_CONFIG_GET(amd_core_clock_percentage)
-DEFINE_CONFIG_GET(amd_mem_clock_percentage)
+
+void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self,
+	                     value,
+	                     &self->values.amd_performance_level,
+	                     sizeof(self->values.amd_performance_level));
+}
 
 /*
         char supervisor_whitelist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];

--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -92,6 +92,7 @@ struct GameModeConfig {
 		long nv_core_clock_mhz_offset;
 		long nv_mem_clock_mhz_offset;
 		long nv_perf_level;
+		long nv_powermizer_mode;
 		char amd_performance_level[CONFIG_VALUE_MAX];
 
 		long require_supervisor;
@@ -258,6 +259,8 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = get_long_value(name, value, &self->values.nv_mem_clock_mhz_offset);
 		} else if (strcmp(name, "nv_perf_level") == 0) {
 			valid = get_long_value(name, value, &self->values.nv_perf_level);
+		} else if (strcmp(name, "nv_powermizer_mode") == 0) {
+			valid = get_long_value(name, value, &self->values.nv_powermizer_mode);
 		} else if (strcmp(name, "amd_performance_level") == 0) {
 			valid = get_string_value(value, self->values.amd_performance_level);
 		}
@@ -330,6 +333,7 @@ static void load_config_files(GameModeConfig *self)
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = -1; /* 0 is a valid device ID so use -1 to indicate no value */
 	self->values.nv_perf_level = -1;
+	self->values.nv_powermizer_mode = -1;
 	self->values.script_timeout = 10; /* Default to 10 seconds for scripts */
 
 	/*
@@ -582,6 +586,7 @@ DEFINE_CONFIG_GET(gpu_device)
 DEFINE_CONFIG_GET(nv_core_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_mem_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_perf_level)
+DEFINE_CONFIG_GET(nv_powermizer_mode)
 
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
 {

--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -71,6 +71,7 @@ struct GameModeConfig {
 		char whitelist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		char blacklist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 
+		long script_timeout;
 		char startscripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		char endscripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 
@@ -278,6 +279,8 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = append_value_to_list(name, value, self->values.startscripts);
 		} else if (strcmp(name, "end") == 0) {
 			valid = append_value_to_list(name, value, self->values.endscripts);
+		} else if (strcmp(name, "script_timeout") == 0) {
+			valid = get_long_value(name, value, &self->values.script_timeout);
 		}
 	}
 
@@ -330,6 +333,7 @@ static void load_config_files(GameModeConfig *self)
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = -1; /* 0 is a valid device ID so use -1 to indicate no value */
 	self->values.nv_perf_level = -1;
+	self->values.script_timeout = 10; /* Default to 10 seconds for scripts */
 
 	/*
 	 * Locations to load, in order
@@ -505,6 +509,11 @@ void config_get_gamemode_end_scripts(GameModeConfig *self,
 {
 	memcpy_locked_config(self, scripts, self->values.endscripts, sizeof(self->values.startscripts));
 }
+
+/*
+ * Get the script timemout value
+ */
+DEFINE_CONFIG_GET(script_timeout)
 
 /*
  * Get the chosen default governor

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -106,6 +106,11 @@ void config_get_gamemode_end_scripts(GameModeConfig *self,
                                      char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX]);
 
 /*
+ * Get the script timout value
+ */
+long config_get_script_timeout(GameModeConfig *self);
+
+/*
  * Get the chosen default governor
  */
 void config_get_default_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -143,6 +143,7 @@ long config_get_gpu_device(GameModeConfig *self);
 long config_get_nv_core_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_perf_level(GameModeConfig *self);
+long config_get_nv_powermizer_mode(GameModeConfig *self);
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
 
 /**

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -143,8 +143,7 @@ long config_get_gpu_device(GameModeConfig *self);
 long config_get_nv_core_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_perf_level(GameModeConfig *self);
-long config_get_amd_core_clock_percentage(GameModeConfig *self);
-long config_get_amd_mem_clock_percentage(GameModeConfig *self);
+void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
 
 /**
  * Functions to get supervisor config permissions

--- a/daemon/external-helper.c
+++ b/daemon/external-helper.c
@@ -40,10 +40,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <time.h>
 #include <unistd.h>
 
+static const int default_timout = 5;
+
 /**
  * Call an external process
  */
-int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX])
+int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX], int tsec)
 {
 	pid_t p;
 	int status = 0;
@@ -52,6 +54,11 @@ int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFF
 	if (pipe(pipes) == -1) {
 		LOG_ERROR("Could not create pipe: %s!\n", strerror(errno));
 		return -1;
+	}
+
+	/* Set the default timeout */
+	if (tsec == -1) {
+		tsec = default_timout;
 	}
 
 	/* set up our signaling for the child and the timout */
@@ -88,7 +95,8 @@ int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFF
 
 	/* Set up the timout */
 	struct timespec timeout;
-	timeout.tv_sec = 5; /* Magic timeout value of 5s for now - should be sane for most commands */
+	timeout.tv_sec = tsec; /* Magic timeout value of 5s for now - should be sane for most commands
+	                        */
 	timeout.tv_nsec = 0;
 
 	/* Wait for the child to finish up with a timout */

--- a/daemon/external-helper.h
+++ b/daemon/external-helper.h
@@ -34,7 +34,4 @@ POSSIBILITY OF SUCH DAMAGE.
 #define EXTERNAL_BUFFER_MAX 1024
 
 /* Run an external process and capture the return value */
-int run_external_process(const char *const *exec_args);
-
-/* Run an external process and capture the return value as well as output */
-int run_external_process_get_output(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);
+int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);

--- a/daemon/external-helper.h
+++ b/daemon/external-helper.h
@@ -34,4 +34,4 @@ POSSIBILITY OF SUCH DAMAGE.
 #define EXTERNAL_BUFFER_MAX 1024
 
 /* Run an external process and capture the return value */
-int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX]);
+int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFFER_MAX], int tsec);

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -140,7 +140,9 @@ int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info)
 		}
 
 		/* Sanity check the performance level value as well */
-		if (new_info->nv_perf_level < 0 || new_info->nv_perf_level > 16) {
+		/* Allow an invalid perf level if we've got the powermizer mode set */
+		if (!(new_info->nv_perf_level == -1 && new_info->nv_powermizer_mode != -1) &&
+		    (new_info->nv_perf_level < 0 || new_info->nv_perf_level > 16)) {
 			LOG_ERROR(
 			    "NVIDIA Performance level value likely invalid (%ld), will not apply "
 			    "optimisations!\n",

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -229,7 +229,7 @@ int game_mode_apply_gpu(const GameModeGPUInfo *info, bool apply)
 		NULL,
 	};
 
-	if (run_external_process(exec_args) != 0) {
+	if (run_external_process(exec_args, NULL) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could not apply optimisations!\n");
 		return -1;
 	}
@@ -262,7 +262,7 @@ int game_mode_get_gpu(GameModeGPUInfo *info)
 	};
 
 	char buffer[EXTERNAL_BUFFER_MAX] = { 0 };
-	if (run_external_process_get_output(exec_args, buffer) != 0) {
+	if (run_external_process(exec_args, buffer) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could get values!\n");
 		return -1;
 	}

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -229,7 +229,7 @@ int game_mode_apply_gpu(const GameModeGPUInfo *info, bool apply)
 		NULL,
 	};
 
-	if (run_external_process(exec_args, NULL) != 0) {
+	if (run_external_process(exec_args, NULL, -1) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could not apply optimisations!\n");
 		return -1;
 	}
@@ -262,7 +262,7 @@ int game_mode_get_gpu(GameModeGPUInfo *info)
 	};
 
 	char buffer[EXTERNAL_BUFFER_MAX] = { 0 };
-	if (run_external_process(exec_args, buffer) != 0) {
+	if (run_external_process(exec_args, buffer, -1) != 0) {
 		LOG_ERROR("Failed to call gpuclockctl, could get values!\n");
 		return -1;
 	}

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -456,6 +456,10 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	char original_amd_performance_level[CONFIG_VALUE_MAX];
 	strncpy(original_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
 
+	/* account for when powermizer is not set */
+	if( expected_nv_powermizer_mode == -1 )
+		expected_nv_powermizer_mode = original_nv_powermizer_mode;
+
 	/* Start gamemode and check the new values */
 	gamemode_request_start();
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -360,6 +360,7 @@ static int run_cpu_governor_tests(struct GameModeConfig *config)
 static int run_custom_scripts_tests(struct GameModeConfig *config)
 {
 	int scriptstatus = 0;
+	long timeout = config_get_script_timeout(config);
 
 	/* Grab and test the start scripts */
 	char startscripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
@@ -372,7 +373,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
-			int ret = run_external_process(args, NULL, 10);
+			int ret = run_external_process(args, NULL, (int)timeout);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -395,7 +396,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
-			int ret = run_external_process(args, NULL, 10);
+			int ret = run_external_process(args, NULL, (int)timeout);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -444,6 +444,7 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	/* Grab the expected values */
 	long expected_core = gpuinfo->nv_core;
 	long expected_mem = gpuinfo->nv_mem;
+	long expected_nv_powermizer_mode = gpuinfo->nv_powermizer_mode;
 	char expected_amd_performance_level[CONFIG_VALUE_MAX];
 	strncpy(expected_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
 
@@ -451,6 +452,7 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	game_mode_get_gpu(gpuinfo);
 	long original_nv_core = gpuinfo->nv_core;
 	long original_nv_mem = gpuinfo->nv_mem;
+	long original_nv_powermizer_mode = gpuinfo->nv_powermizer_mode;
 	char original_amd_performance_level[CONFIG_VALUE_MAX];
 	strncpy(original_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
 
@@ -465,14 +467,18 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	}
 
 	if (gpuinfo->vendor == Vendor_NVIDIA &&
-	    (gpuinfo->nv_core != expected_core || gpuinfo->nv_mem != expected_mem)) {
+	    (gpuinfo->nv_core != expected_core || gpuinfo->nv_mem != expected_mem ||
+	     gpuinfo->nv_powermizer_mode != expected_nv_powermizer_mode)) {
 		LOG_ERROR(
 		    "Current Nvidia GPU clocks during gamemode do not match requested values!\n"
-		    "\tnv_core - expected:%ld was:%ld | nv_mem - expected:%ld was:%ld\n",
+		    "\tnv_core - expected:%ld was:%ld | nv_mem - expected:%ld was:%ld | nv_powermizer_mode "
+		    "- expected:%ld was:%ld\n",
 		    expected_core,
 		    gpuinfo->nv_core,
 		    expected_mem,
-		    gpuinfo->nv_mem);
+		    gpuinfo->nv_mem,
+		    expected_nv_powermizer_mode,
+		    gpuinfo->nv_powermizer_mode);
 		gpustatus = -1;
 	} else if (gpuinfo->vendor == Vendor_AMD &&
 	           strcmp(expected_amd_performance_level, gpuinfo->amd_performance_level) != 0) {
@@ -494,14 +500,18 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	}
 
 	if (gpuinfo->vendor == Vendor_NVIDIA &&
-	    (gpuinfo->nv_core != original_nv_core || gpuinfo->nv_mem != original_nv_mem)) {
+	    (gpuinfo->nv_core != original_nv_core || gpuinfo->nv_mem != original_nv_mem ||
+	     gpuinfo->nv_powermizer_mode != original_nv_powermizer_mode)) {
 		LOG_ERROR(
 		    "Current Nvidia GPU clocks after gamemode do not matcch original values!\n"
-		    "\tcore - original:%ld was:%ld | nv_mem - original:%ld was:%ld\n",
+		    "\tnv_core - original:%ld was:%ld | nv_mem - original:%ld was:%ld | nv_powermizer_mode "
+		    "- original:%ld was:%ld\n",
 		    original_nv_core,
 		    gpuinfo->nv_core,
 		    original_nv_mem,
-		    gpuinfo->nv_mem);
+		    gpuinfo->nv_mem,
+		    original_nv_powermizer_mode,
+		    gpuinfo->nv_powermizer_mode);
 		gpustatus = -1;
 	} else if (gpuinfo->vendor == Vendor_AMD &&
 	           strcmp(original_amd_performance_level, gpuinfo->amd_performance_level) != 0) {

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -457,7 +457,7 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	strncpy(original_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
 
 	/* account for when powermizer is not set */
-	if( expected_nv_powermizer_mode == -1 )
+	if (expected_nv_powermizer_mode == -1)
 		expected_nv_powermizer_mode = original_nv_powermizer_mode;
 
 	/* Start gamemode and check the new values */

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -372,7 +372,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
-			int ret = run_external_process(args, NULL);
+			int ret = run_external_process(args, NULL, 10);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -395,7 +395,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
-			int ret = run_external_process(args, NULL);
+			int ret = run_external_process(args, NULL, 10);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 
 #include "daemon_config.h"
+#include "external-helper.h"
 #include "gamemode_client.h"
 #include "governors-query.h"
 #include "gpu-control.h"
@@ -370,7 +371,8 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 		while (*startscripts[i] != '\0' && i < CONFIG_LIST_MAX) {
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
-			int ret = system(startscripts[i]);
+			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
+			int ret = run_external_process(args);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -392,7 +394,8 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 		while (*endscripts[i] != '\0' && i < CONFIG_LIST_MAX) {
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
-			int ret = system(endscripts[i]);
+			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
+			int ret = run_external_process(args);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -442,15 +442,15 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	}
 
 	/* Grab the expected values */
-	long expected_core = gpuinfo->core;
-	long expected_mem = gpuinfo->mem;
+	long expected_core = gpuinfo->nv_core;
+	long expected_mem = gpuinfo->nv_mem;
 
 	/* Get current stats */
 	game_mode_get_gpu(gpuinfo);
-	long original_core = gpuinfo->core;
-	long original_mem = gpuinfo->mem;
+	long original_core = gpuinfo->nv_core;
+	long original_mem = gpuinfo->nv_mem;
 
-	LOG_MSG("Configured with vendor:0x%04x device:%ld core:%ld mem:%ld (nv_perf_level:%ld)\n",
+	LOG_MSG("Configured with vendor:0x%04x device:%ld nv_core:%ld nv_mem:%ld (nv_perf_level:%ld)\n",
 	        (unsigned int)gpuinfo->vendor,
 	        gpuinfo->device,
 	        expected_core,
@@ -467,14 +467,14 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 		return -1;
 	}
 
-	if (gpuinfo->core != expected_core || gpuinfo->mem != expected_mem) {
+	if (gpuinfo->nv_core != expected_core || gpuinfo->nv_mem != expected_mem) {
 		LOG_ERROR(
 		    "Current GPU clocks during gamemode do not match requested values!\n"
-		    "\tcore - expected:%ld was:%ld | mem - expected:%ld was:%ld\n",
+		    "\tnv_core - expected:%ld was:%ld | nv_mem - expected:%ld was:%ld\n",
 		    expected_core,
-		    gpuinfo->core,
+		    gpuinfo->nv_core,
 		    expected_mem,
-		    gpuinfo->mem);
+		    gpuinfo->nv_mem);
 		gpustatus = -1;
 	}
 
@@ -487,14 +487,14 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 		return -1;
 	}
 
-	if (gpuinfo->core != original_core || gpuinfo->mem != original_mem) {
+	if (gpuinfo->nv_core != original_core || gpuinfo->nv_mem != original_mem) {
 		LOG_ERROR(
 		    "Current GPU clocks after gamemode do not matcch original values!\n"
-		    "\tcore - original:%ld was:%ld | mem - original:%ld was:%ld\n",
+		    "\tcore - original:%ld was:%ld | nv_mem - original:%ld was:%ld\n",
 		    original_core,
-		    gpuinfo->core,
+		    gpuinfo->nv_core,
 		    original_mem,
-		    gpuinfo->mem);
+		    gpuinfo->nv_mem);
 		gpustatus = -1;
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -201,8 +201,8 @@ static int run_dual_client_tests(void)
 	/* Parent process */
 	/* None of these should early-out as we need to clean up the child */
 
-	/* Give the child a chance to reqeust gamemode */
-	usleep(1000);
+	/* Give the child a chance to request gamemode */
+	usleep(10000);
 
 	/* Check that when we request gamemode, it replies that the other client is connected */
 	if (verify_other_client_connected() != 0)

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -372,7 +372,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running start script [%s]\n", startscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", startscripts[i], NULL };
-			int ret = run_external_process(args);
+			int ret = run_external_process(args, NULL);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");
@@ -395,7 +395,7 @@ static int run_custom_scripts_tests(struct GameModeConfig *config)
 			LOG_MSG(":::: Running end script [%s]\n", endscripts[i]);
 
 			const char *args[] = { "/bin/sh", "-c", endscripts[i], NULL };
-			int ret = run_external_process(args);
+			int ret = run_external_process(args, NULL);
 
 			if (ret == 0)
 				LOG_MSG(":::: Passed\n");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -319,12 +319,11 @@ static int run_cpu_governor_tests(struct GameModeConfig *config)
 		strcpy(desiredgov, "performance");
 
 	char defaultgov[CONFIG_VALUE_MAX] = { 0 };
-	config_get_default_governor(config, defaultgov);
 
-	if (desiredgov[0] == '\0') {
+	if (defaultgov[0] == '\0') {
 		const char *currentgov = get_gov_state();
 		if (currentgov) {
-			strncpy(desiredgov, currentgov, CONFIG_VALUE_MAX);
+			strncpy(defaultgov, currentgov, CONFIG_VALUE_MAX);
 		} else {
 			LOG_ERROR(
 			    "Could not get current CPU governor state, this indicates an error! See rest "

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -93,6 +93,7 @@ static void *game_mode_context_reaper(void *userdata);
 static void game_mode_context_enter(GameModeContext *self);
 static void game_mode_context_leave(GameModeContext *self);
 static char *game_mode_context_find_exe(pid_t pid);
+static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX]);
 
 void game_mode_context_init(GameModeContext *self)
 {
@@ -208,17 +209,7 @@ static void game_mode_context_enter(GameModeContext *self)
 	char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 	memset(scripts, 0, sizeof(scripts));
 	config_get_gamemode_start_scripts(self->config, scripts);
-
-	unsigned int i = 0;
-	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
-		LOG_MSG("Executing script [%s]\n", scripts[i]);
-		int err;
-		if ((err = system(scripts[i])) != 0) {
-			/* Log the failure, but this is not fatal */
-			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
-		}
-		i++;
-	}
+	game_mode_execute_scripts(scripts);
 }
 
 /**
@@ -261,17 +252,7 @@ static void game_mode_context_leave(GameModeContext *self)
 	char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 	memset(scripts, 0, sizeof(scripts));
 	config_get_gamemode_end_scripts(self->config, scripts);
-
-	unsigned int i = 0;
-	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
-		LOG_MSG("Executing script [%s]\n", scripts[i]);
-		int err;
-		if ((err = system(scripts[i])) != 0) {
-			/* Log the failure, but this is not fatal */
-			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
-		}
-		i++;
-	}
+	game_mode_execute_scripts(scripts);
 }
 
 /**
@@ -702,4 +683,19 @@ fail:
 	if (errno != 0) // otherwise a proper message was logged before
 		LOG_ERROR("Unable to find executable for PID %d: %s\n", pid, strerror(errno));
 	return NULL;
+}
+
+/* Executes a set of scripts */
+static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE_MAX])
+{
+	unsigned int i = 0;
+	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
+		LOG_MSG("Executing script [%s]\n", scripts[i]);
+		int err;
+		if ((err = system(scripts[i])) != 0) {
+			/* Log the failure, but this is not fatal */
+			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
+		}
+		i++;
+	}
 }

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -692,7 +692,8 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 	while (*scripts[i] != '\0' && i < CONFIG_LIST_MAX) {
 		LOG_MSG("Executing script [%s]\n", scripts[i]);
 		int err;
-		if ((err = system(scripts[i])) != 0) {
+		const char *args[] = { "/bin/sh", "-c", scripts[i], NULL };
+		if ((err = run_external_process(args)) != 0) {
 			/* Log the failure, but this is not fatal */
 			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
 		}

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -189,7 +189,7 @@ static void game_mode_context_enter(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", desiredGov);
-		if (run_external_process(exec_args) != 0) {
+		if (run_external_process(exec_args, NULL) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 			/* if the set fails, clear the initial mode so we don't try and reset it back and fail
 			 * again, presumably */
@@ -242,7 +242,7 @@ static void game_mode_context_leave(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", gov_mode);
-		if (run_external_process(exec_args) != 0) {
+		if (run_external_process(exec_args, NULL) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 		}
 
@@ -693,7 +693,7 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 		LOG_MSG("Executing script [%s]\n", scripts[i]);
 		int err;
 		const char *args[] = { "/bin/sh", "-c", scripts[i], NULL };
-		if ((err = run_external_process(args)) != 0) {
+		if ((err = run_external_process(args, NULL)) != 0) {
 			/* Log the failure, but this is not fatal */
 			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
 		}

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -189,7 +189,7 @@ static void game_mode_context_enter(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", desiredGov);
-		if (run_external_process(exec_args, NULL) != 0) {
+		if (run_external_process(exec_args, NULL, -1) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 			/* if the set fails, clear the initial mode so we don't try and reset it back and fail
 			 * again, presumably */
@@ -242,7 +242,7 @@ static void game_mode_context_leave(GameModeContext *self)
 		};
 
 		LOG_MSG("Requesting update of governor policy to %s\n", gov_mode);
-		if (run_external_process(exec_args, NULL) != 0) {
+		if (run_external_process(exec_args, NULL, -1) != 0) {
 			LOG_ERROR("Failed to update cpu governor policy\n");
 		}
 
@@ -693,7 +693,7 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 		LOG_MSG("Executing script [%s]\n", scripts[i]);
 		int err;
 		const char *args[] = { "/bin/sh", "-c", scripts[i], NULL };
-		if ((err = run_external_process(args, NULL)) != 0) {
+		if ((err = run_external_process(args, NULL, 10)) != 0) {
 			/* Log the failure, but this is not fatal */
 			LOG_ERROR("Script [%s] failed with error %d\n", scripts[i], err);
 		}

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -150,5 +150,5 @@ int game_mode_run_client_tests(void);
 typedef struct GameModeGPUInfo GameModeGPUInfo;
 int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info);
 void game_mode_free_gpu(GameModeGPUInfo **info);
-int game_mode_apply_gpu(const GameModeGPUInfo *info, bool apply);
+int game_mode_apply_gpu(const GameModeGPUInfo *info);
 int game_mode_get_gpu(GameModeGPUInfo *info);

--- a/daemon/gpu-control.h
+++ b/daemon/gpu-control.h
@@ -47,8 +47,8 @@ struct GameModeGPUInfo {
 	long vendor;
 	long device; /* path to device, ie. /sys/class/drm/card#/ */
 
-	long core; /* Core clock to apply */
-	long mem;  /* Mem clock to apply */
+	long nv_core; /* Core clock to apply */
+	long nv_mem;  /* Mem clock to apply */
 
 	long nv_perf_level; /* The Nvidia Performance Level to adjust */
 };

--- a/daemon/gpu-control.h
+++ b/daemon/gpu-control.h
@@ -30,6 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
+#include "daemon_config.h"
 
 /* Enums for GPU vendors */
 enum GPUVendor {
@@ -45,10 +46,11 @@ enum GPUVendor {
 /* Storage for GPU info*/
 struct GameModeGPUInfo {
 	long vendor;
-	long device; /* path to device, ie. /sys/class/drm/card#/ */
-
-	long nv_core; /* Core clock to apply */
-	long nv_mem;  /* Mem clock to apply */
-
+	long device;        /* path to device, ie. /sys/class/drm/card#/ */
 	long nv_perf_level; /* The Nvidia Performance Level to adjust */
+
+	long nv_core; /* Nvidia core clock */
+	long nv_mem;  /* Nvidia mem clock */
+
+	char amd_performance_level[CONFIG_VALUE_MAX]; /* The AMD performance level set to */
 };

--- a/daemon/gpu-control.h
+++ b/daemon/gpu-control.h
@@ -49,8 +49,9 @@ struct GameModeGPUInfo {
 	long device;        /* path to device, ie. /sys/class/drm/card#/ */
 	long nv_perf_level; /* The Nvidia Performance Level to adjust */
 
-	long nv_core; /* Nvidia core clock */
-	long nv_mem;  /* Nvidia mem clock */
+	long nv_core;            /* Nvidia core clock */
+	long nv_mem;             /* Nvidia mem clock */
+	long nv_powermizer_mode; /* NV Powermizer Mode */
 
 	char amd_performance_level[CONFIG_VALUE_MAX]; /* The AMD performance level set to */
 };

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -84,7 +84,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 		return -1;
 	}
 
-	info->core = strtol(buf, &end, 10);
+	info->nv_core = strtol(buf, &end, 10);
 	if (end == buf) {
 		LOG_ERROR("Failed to parse output for \"%s\" output was \"%s\"!\n", arg, buf);
 		return -1;
@@ -103,7 +103,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 		return -1;
 	}
 
-	info->mem = strtol(buf, &end, 10);
+	info->nv_mem = strtol(buf, &end, 10);
 	if (end == buf) {
 		LOG_ERROR("Failed to parse output for \"%s\" output was \"%s\"!\n", arg, buf);
 		return -1;
@@ -143,7 +143,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->device,
 	         NV_CORE_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level,
-	         info->core);
+	         info->nv_core);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", core_arg, NULL };
 	if (run_external_process(exec_args_core, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", core_arg);
@@ -158,7 +158,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->device,
 	         NV_MEM_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level,
-	         info->mem);
+	         info->nv_mem);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", mem_arg, NULL };
 	if (run_external_process(exec_args_mem, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", mem_arg);
@@ -212,10 +212,10 @@ static int set_gpu_state_amd(struct GameModeGPUInfo *info)
 		print_usage_and_exit();
 	}
 
-	// Set the the core and mem clock speeds using the OverDrive files
-	if (set_gpu_state_amd_file("pp_sclk_od", info->device, info->core) != 0)
+	// Set the the nv_core and nv_mem clock speeds using the OverDrive files
+	if (set_gpu_state_amd_file("pp_sclk_od", info->device, info->nv_core) != 0)
 		return -1;
-	if (set_gpu_state_amd_file("pp_mclk_od", info->device, info->mem) != 0)
+	if (set_gpu_state_amd_file("pp_mclk_od", info->device, info->nv_mem) != 0)
 		return -1;
 
 	return 0;
@@ -245,7 +245,7 @@ static long get_device(const char *val)
 	return ret;
 }
 
-/* Helper to get and verify core and mem value */
+/* Helper to get and verify nv_core and nv_mem value */
 static long get_generic_value(const char *val)
 {
 	char *end;
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
 			printf("Currently unsupported GPU vendor 0x%04x, doing nothing!\n", (short)info.vendor);
 			break;
 		}
-		printf("%ld %ld\n", info.core, info.mem);
+		printf("%ld %ld\n", info.nv_core, info.nv_mem);
 
 	} else if (argc >= 6 && argc <= 7 && strncmp(argv[3], "set", 3) == 0) {
 		/* Get and verify the vendor and device */
@@ -295,15 +295,15 @@ int main(int argc, char *argv[])
 		memset(&info, 0, sizeof(info));
 		info.vendor = get_vendor(argv[1]);
 		info.device = get_device(argv[2]);
-		info.core = get_generic_value(argv[4]);
-		info.mem = get_generic_value(argv[5]);
+		info.nv_core = get_generic_value(argv[4]);
+		info.nv_mem = get_generic_value(argv[5]);
 
 		if (info.vendor == Vendor_NVIDIA && argc > 6)
 			info.nv_perf_level = get_generic_value(argv[6]);
 
-		printf("gpuclockctl setting core:%ld mem:%ld on device:%ld with vendor 0x%04x\n",
-		       info.core,
-		       info.mem,
+		printf("gpuclockctl setting nv_core:%ld nv_mem:%ld on device:%ld with vendor 0x%04x\n",
+		       info.nv_core,
+		       info.nv_mem,
 		       info.device,
 		       (unsigned short)info.vendor);
 

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -79,7 +79,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_CORE_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process(exec_args_core, buf) != 0) {
+	if (run_external_process(exec_args_core, buf, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -98,7 +98,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_MEM_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process(exec_args_mem, buf) != 0) {
+	if (run_external_process(exec_args_mem, buf, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -145,7 +145,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->core);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", core_arg, NULL };
-	if (run_external_process(exec_args_core, NULL) != 0) {
+	if (run_external_process(exec_args_core, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", core_arg);
 		return -1;
 	}
@@ -160,7 +160,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->mem);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", mem_arg, NULL };
-	if (run_external_process(exec_args_mem, NULL) != 0) {
+	if (run_external_process(exec_args_mem, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", mem_arg);
 		return -1;
 	}

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -79,7 +79,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_CORE_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process_get_output(exec_args_core, buf) != 0) {
+	if (run_external_process(exec_args_core, buf) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -98,7 +98,7 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	         NV_MEM_OFFSET_ATTRIBUTE,
 	         info->nv_perf_level);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process_get_output(exec_args_mem, buf) != 0) {
+	if (run_external_process(exec_args_mem, buf) != 0) {
 		LOG_ERROR("Failed to set %s!\n", arg);
 		return -1;
 	}
@@ -145,7 +145,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->core);
 	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", core_arg, NULL };
-	if (run_external_process(exec_args_core) != 0) {
+	if (run_external_process(exec_args_core, NULL) != 0) {
 		LOG_ERROR("Failed to set %s!\n", core_arg);
 		return -1;
 	}
@@ -160,7 +160,7 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 	         info->nv_perf_level,
 	         info->mem);
 	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", mem_arg, NULL };
-	if (run_external_process(exec_args_mem) != 0) {
+	if (run_external_process(exec_args_mem, NULL) != 0) {
 		LOG_ERROR("Failed to set %s!\n", mem_arg);
 		return -1;
 	}

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -73,42 +73,44 @@ static int get_gpu_state_nv(struct GameModeGPUInfo *info)
 	char buf[EXTERNAL_BUFFER_MAX] = { 0 };
 	char *end;
 
-	/* Get the GPUGraphicsClockOffset parameter */
-	snprintf(arg,
-	         128,
-	         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT,
-	         info->device,
-	         NV_CORE_OFFSET_ATTRIBUTE,
-	         info->nv_perf_level);
-	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process(exec_args_core, buf, -1) != 0) {
-		LOG_ERROR("Failed to get %s!\n", arg);
-		return -1;
-	}
+	if (info->nv_perf_level != -1) {
+		/* Get the GPUGraphicsClockOffset parameter */
+		snprintf(arg,
+		         128,
+		         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT,
+		         info->device,
+		         NV_CORE_OFFSET_ATTRIBUTE,
+		         info->nv_perf_level);
+		const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
+		if (run_external_process(exec_args_core, buf, -1) != 0) {
+			LOG_ERROR("Failed to get %s!\n", arg);
+			return -1;
+		}
 
-	info->nv_core = strtol(buf, &end, 10);
-	if (end == buf) {
-		LOG_ERROR("Failed to parse output for \"%s\" output was \"%s\"!\n", arg, buf);
-		return -1;
-	}
+		info->nv_core = strtol(buf, &end, 10);
+		if (end == buf) {
+			LOG_ERROR("Failed to parse output for \"%s\" output was \"%s\"!\n", arg, buf);
+			return -1;
+		}
 
-	/* Get the GPUMemoryTransferRateOffset parameter */
-	snprintf(arg,
-	         128,
-	         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT,
-	         info->device,
-	         NV_MEM_OFFSET_ATTRIBUTE,
-	         info->nv_perf_level);
-	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
-	if (run_external_process(exec_args_mem, buf, -1) != 0) {
-		LOG_ERROR("Failed to get %s!\n", arg);
-		return -1;
-	}
+		/* Get the GPUMemoryTransferRateOffset parameter */
+		snprintf(arg,
+		         128,
+		         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT,
+		         info->device,
+		         NV_MEM_OFFSET_ATTRIBUTE,
+		         info->nv_perf_level);
+		const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-q", arg, "-t", NULL };
+		if (run_external_process(exec_args_mem, buf, -1) != 0) {
+			LOG_ERROR("Failed to get %s!\n", arg);
+			return -1;
+		}
 
-	info->nv_mem = strtol(buf, &end, 10);
-	if (end == buf) {
-		LOG_ERROR("Failed to parse output for \"%s\" output was \"%s\"!\n", arg, buf);
-		return -1;
+		info->nv_mem = strtol(buf, &end, 10);
+		if (end == buf) {
+			LOG_ERROR("Failed to parse output for \"%s\" output was \"%s\"!\n", arg, buf);
+			return -1;
+		}
 	}
 
 	/* Get the GPUPowerMizerMode parameter */
@@ -143,48 +145,49 @@ static int set_gpu_state_nv(struct GameModeGPUInfo *info)
 
 	char arg[128] = { 0 };
 
-	/* Set the GPUGraphicsClockOffset parameter */
-	snprintf(arg,
-	         128,
-	         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT "=%ld",
-	         info->device,
-	         NV_CORE_OFFSET_ATTRIBUTE,
-	         info->nv_perf_level,
-	         info->nv_core);
-	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", arg, NULL };
-	if (run_external_process(exec_args_core, NULL, -1) != 0) {
-		LOG_ERROR("Failed to set %s!\n", arg);
-		return -1;
-	}
+	if (info->nv_perf_level != -1) {
+		/* Set the GPUGraphicsClockOffset parameter */
+		snprintf(arg,
+		         128,
+		         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT "=%ld",
+		         info->device,
+		         NV_CORE_OFFSET_ATTRIBUTE,
+		         info->nv_perf_level,
+		         info->nv_core);
+		const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", arg, NULL };
+		if (run_external_process(exec_args_core, NULL, -1) != 0) {
+			LOG_ERROR("Failed to set %s!\n", arg);
+			return -1;
+		}
 
-	/* Set the GPUMemoryTransferRateOffset parameter */
-	snprintf(arg,
-	         128,
-	         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT "=%ld",
-	         info->device,
-	         NV_MEM_OFFSET_ATTRIBUTE,
-	         info->nv_perf_level,
-	         info->nv_mem);
-	const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", arg, NULL };
-	if (run_external_process(exec_args_mem, NULL, -1) != 0) {
-		LOG_ERROR("Failed to set %s!\n", arg);
-		return -1;
+		/* Set the GPUMemoryTransferRateOffset parameter */
+		snprintf(arg,
+		         128,
+		         NV_ATTRIBUTE_FORMAT NV_PERF_LEVEL_FORMAT "=%ld",
+		         info->device,
+		         NV_MEM_OFFSET_ATTRIBUTE,
+		         info->nv_perf_level,
+		         info->nv_mem);
+		const char *exec_args_mem[] = { "/usr/bin/nvidia-settings", "-a", arg, NULL };
+		if (run_external_process(exec_args_mem, NULL, -1) != 0) {
+			LOG_ERROR("Failed to set %s!\n", arg);
+			return -1;
+		}
 	}
 
 	/* Set the GPUPowerMizerMode parameter if requested */
-	if (info->nv_powermizer_mode == -1)
-		return 0;
-
-	snprintf(arg,
-	         128,
-	         NV_ATTRIBUTE_FORMAT "=%ld",
-	         info->device,
-	         NV_POWERMIZER_MODE_ATTRIBUTE,
-	         info->nv_powermizer_mode);
-	const char *exec_args_pm[] = { "/usr/bin/nvidia-settings", "-a", arg, NULL };
-	if (run_external_process(exec_args_pm, NULL, -1) != 0) {
-		LOG_ERROR("Failed to set %s!\n", arg);
-		return -1;
+	if (info->nv_powermizer_mode != -1) {
+		snprintf(arg,
+		         128,
+		         NV_ATTRIBUTE_FORMAT "=%ld",
+		         info->device,
+		         NV_POWERMIZER_MODE_ATTRIBUTE,
+		         info->nv_powermizer_mode);
+		const char *exec_args_pm[] = { "/usr/bin/nvidia-settings", "-a", arg, NULL };
+		if (run_external_process(exec_args_pm, NULL, -1) != 0) {
+			LOG_ERROR("Failed to set %s!\n", arg);
+			return -1;
+		}
 	}
 
 	return 0;
@@ -310,7 +313,7 @@ static long get_generic_value(const char *val)
 {
 	char *end;
 	long ret = strtol(val, &end, 10);
-	if (ret < 0 || end == val) {
+	if (end == val) {
 		LOG_ERROR("Invalid value passed (%ld)!\n", ret);
 		print_usage_and_exit();
 	}
@@ -329,12 +332,12 @@ int main(int argc, char *argv[])
 		info.vendor = get_vendor(argv[1]);
 		info.device = get_device(argv[2]);
 
-		if (info.vendor == Vendor_NVIDIA && argc > 4)
-			info.nv_perf_level = get_generic_value(argv[4]);
-
 		/* Fetch the state and print it out */
 		switch (info.vendor) {
 		case Vendor_NVIDIA:
+			info.nv_perf_level = -1;
+			if (argc > 4)
+				info.nv_perf_level = get_generic_value(argv[4]);
 			/* Get nvidia power level */
 			if (get_gpu_state_nv(&info) != 0)
 				exit(EXIT_FAILURE);
@@ -361,12 +364,12 @@ int main(int argc, char *argv[])
 		case Vendor_NVIDIA:
 			info.nv_core = get_generic_value(argv[4]);
 			info.nv_mem = get_generic_value(argv[5]);
+			info.nv_perf_level = -1;
 			if (argc > 6)
 				info.nv_perf_level = get_generic_value(argv[6]);
+			info.nv_powermizer_mode = -1;
 			if (argc > 7)
 				info.nv_powermizer_mode = get_generic_value(argv[7]);
-			else
-				info.nv_powermizer_mode = -1;
 			break;
 		case Vendor_AMD:
 			strncpy(info.amd_performance_level, argv[4], CONFIG_VALUE_MAX);

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -50,14 +50,15 @@ inhibit_screensaver=1
 ; Requires the coolbits extension activated in nvidia-xconfig
 ;nv_core_clock_mhz_offset=0
 ;nv_mem_clock_mhz_offset=0
-; This corresponds to the performance level to edit in nvidia-xconfig
+; This corresponds to the performance level to edit in nvidia-xconfig (usually the highest level - on older cards 1, newer cards can be 4 or higher)
 ;nv_perf_level=1
 
-; AMD specific settings (these are percentages applied on top of the baseline, ie. 0 applies no change)
-; Requires the the AMDGPU kernel module
+; AMD specific settings
+; Requires a relatively up to date AMDGPU kernel module
+; See: https://dri.freedesktop.org/docs/drm/gpu/amdgpu.html#gpu-power-thermal-controls-and-monitoring
 ; It is also highly recommended you use lm-sensors (or other available tools) to verify card temperatures
-;amd_core_clock_percentage=0
-;amd_mem_clock_percentage=0
+; This corresponds to power_dpm_force_performance_level, "manual" is not supported for now
+;amd_performance_level=high
 
 [supervisor]
 ; This section controls the new gamemode functions gamemode_request_start_for and gamemode_request_end_for

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -46,12 +46,17 @@ inhibit_screensaver=1
 ; The DRM device number on the system (usually 0), ie. the number in /sys/class/drm/card0/
 ;gpu_device=0
 
-; Nvidia specific settings (these are Mhz offsets from the baseline, ie. 0 applies no change)
+; Nvidia specific settings
 ; Requires the coolbits extension activated in nvidia-xconfig
-;nv_core_clock_mhz_offset=0
-;nv_mem_clock_mhz_offset=0
+; This corresponds to the desired GPUPowerMizerMode
+; Generally "Adaptive"=0 "Prefer Maximum Performance"=1 and "Auto"=2)
+;nv_powermizer_mode=1
+
 ; This corresponds to the performance level to edit in nvidia-xconfig (usually the highest level - on older cards 1, newer cards can be 4 or higher)
 ;nv_perf_level=1
+; (these two are Mhz offsets from the baseline, ie. 0 applies no change)
+;nv_core_clock_mhz_offset=0
+;nv_mem_clock_mhz_offset=0
 
 ; AMD specific settings
 ; Requires a relatively up to date AMDGPU kernel module

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -47,6 +47,8 @@ static int gamemode_request(const char *function, int arg)
 {
 	sd_bus_message *msg = NULL;
 	sd_bus *bus = NULL;
+	sd_bus_error err;
+	memset(&err, 0, sizeof(err));
 
 	int result = -1;
 
@@ -64,7 +66,7 @@ static int gamemode_request(const char *function, int arg)
 		                         "/com/feralinteractive/GameMode",
 		                         "com.feralinteractive.GameMode",
 		                         function,
-		                         NULL,
+		                         &err,
 		                         &msg,
 		                         arg ? "ii" : "i",
 		                         getpid(),
@@ -72,7 +74,13 @@ static int gamemode_request(const char *function, int arg)
 		if (ret < 0) {
 			snprintf(error_string,
 			         sizeof(error_string),
-			         "Could not call method on bus: %s",
+			         "Could not call method %s on com.feralinteractive.GameMode\n"
+			         "\t%s\n"
+			         "\t%s\n"
+			         "\t%s\n",
+			         function,
+			         err.name,
+			         err.message,
 			         strerror(-ret));
 		} else {
 			// Read the reply


### PR DESCRIPTION
Applies on top of #108.

* Allows controlling `GPUPowerMizerMode` on Nvidia (`nv_powermizer_mode` in config)
* Allows controlling the `power_dpm_force_performance_level` file on AMD (`amd_performance_level` in config)
* Removes non-functioning `amd_core_clock_percentage` and `amd_mem_clock_percentage`, fully featured amd overclock tweaks can come later
* Implements properly getting the GPU state on AMD and Nvidia, so that GameMode always tries to return the state back to the way it found it
