### PR TITLE
Clean up NV optimization config

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -91,7 +91,6 @@ struct GameModeConfig {
 		long gpu_device;
 		long nv_core_clock_mhz_offset;
 		long nv_mem_clock_mhz_offset;
-		long nv_perf_level;
 		long nv_powermizer_mode;
 		char amd_performance_level[CONFIG_VALUE_MAX];
 
@@ -257,8 +256,6 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = get_long_value(name, value, &self->values.nv_core_clock_mhz_offset);
 		} else if (strcmp(name, "nv_mem_clock_mhz_offset") == 0) {
 			valid = get_long_value(name, value, &self->values.nv_mem_clock_mhz_offset);
-		} else if (strcmp(name, "nv_perf_level") == 0) {
-			valid = get_long_value(name, value, &self->values.nv_perf_level);
 		} else if (strcmp(name, "nv_powermizer_mode") == 0) {
 			valid = get_long_value(name, value, &self->values.nv_powermizer_mode);
 		} else if (strcmp(name, "amd_performance_level") == 0) {
@@ -332,8 +329,9 @@ static void load_config_files(GameModeConfig *self)
 	self->values.renice = 4;              /* default value of 4 */
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = -1; /* 0 is a valid device ID so use -1 to indicate no value */
-	self->values.nv_perf_level = -1;
 	self->values.nv_powermizer_mode = -1;
+	self->values.nv_core_clock_mhz_offset = -1;
+	self->values.nv_mem_clock_mhz_offset = -1;
 	self->values.script_timeout = 10; /* Default to 10 seconds for scripts */
 
 	/*
@@ -585,7 +583,6 @@ void config_get_apply_gpu_optimisations(GameModeConfig *self, char value[CONFIG_
 DEFINE_CONFIG_GET(gpu_device)
 DEFINE_CONFIG_GET(nv_core_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_mem_clock_mhz_offset)
-DEFINE_CONFIG_GET(nv_perf_level)
 DEFINE_CONFIG_GET(nv_powermizer_mode)
 
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX])

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -142,7 +142,6 @@ void config_get_apply_gpu_optimisations(GameModeConfig *self, char value[CONFIG_
 long config_get_gpu_device(GameModeConfig *self);
 long config_get_nv_core_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);
-long config_get_nv_perf_level(GameModeConfig *self);
 long config_get_nv_powermizer_mode(GameModeConfig *self);
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -456,9 +456,13 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	char original_amd_performance_level[CONFIG_VALUE_MAX];
 	strncpy(original_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
 
-	/* account for when powermizer is not set */
+	/* account for when settings are not set */
 	if (expected_nv_powermizer_mode == -1)
 		expected_nv_powermizer_mode = original_nv_powermizer_mode;
+	if (expected_core == -1)
+		expected_core = original_nv_core;
+	if (expected_mem == -1)
+		expected_mem = original_nv_mem;
 
 	/* Start gamemode and check the new values */
 	gamemode_request_start();

--- a/daemon/gpu-control.c
+++ b/daemon/gpu-control.c
@@ -28,33 +28,45 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
  */
+#include "gpu-control.h"
+#include "logging.h"
 
-#pragma once
-#include "daemon_config.h"
-
-/* Enums for GPU vendors */
-enum GPUVendor {
-	Vendor_Invalid = 0,
-	Vendor_NVIDIA = 0x10de,
-	Vendor_AMD = 0x1002,
-	Vendor_Intel = 0x8086
-};
-
-#define GPUVendorValid(vendor)                                                                     \
-	(vendor == Vendor_NVIDIA || vendor == Vendor_AMD || vendor == Vendor_Intel)
-
-/* Storage for GPU info*/
-struct GameModeGPUInfo {
-	long vendor;
-	long device;        /* path to device, ie. /sys/class/drm/card#/ */
-	long nv_perf_level; /* The Nvidia Performance Level to adjust */
-
-	long nv_core;            /* Nvidia core clock */
-	long nv_mem;             /* Nvidia mem clock */
-	long nv_powermizer_mode; /* NV Powermizer Mode */
-
-	char amd_performance_level[CONFIG_VALUE_MAX]; /* The AMD performance level set to */
-};
+#include <stdio.h>
 
 /* Get the vendor for a device */
-enum GPUVendor gamemode_get_gpu_vendor(long device);
+enum GPUVendor gamemode_get_gpu_vendor(long device)
+{
+	enum GPUVendor vendor = Vendor_Invalid;
+
+	/* Fill in GPU vendor */
+	char path[64] = { 0 };
+	if (snprintf(path, 64, "/sys/class/drm/card%ld/device/vendor", device) < 0) {
+		LOG_ERROR("snprintf failed, will not apply gpu optimisations!\n");
+		return Vendor_Invalid;
+	}
+	FILE *file = fopen(path, "r");
+	if (!file) {
+		LOG_ERROR("Couldn't open vendor file at %s, will not apply gpu optimisations!\n", path);
+		return Vendor_Invalid;
+	}
+	char buff[64];
+	if (fgets(buff, 64, file) != NULL) {
+		vendor = strtol(buff, NULL, 0);
+	} else {
+		LOG_ERROR("Coudn't read contents of file %s, will not apply optimisations!\n", path);
+		return Vendor_Invalid;
+	}
+
+	/* verify GPU vendor */
+	if (!GPUVendorValid(vendor)) {
+		LOG_ERROR("Unknown vendor value (0x%04x) found, cannot apply optimisations!\n",
+		          (unsigned int)vendor);
+		LOG_ERROR("Known values are: 0x%04x (NVIDIA) 0x%04x (AMD) 0x%04x (Intel)\n",
+		          Vendor_NVIDIA,
+		          Vendor_AMD,
+		          Vendor_Intel);
+		return Vendor_Invalid;
+	}
+
+	return vendor;
+}

--- a/daemon/gpu-control.h
+++ b/daemon/gpu-control.h
@@ -46,8 +46,7 @@ enum GPUVendor {
 /* Storage for GPU info*/
 struct GameModeGPUInfo {
 	long vendor;
-	long device;        /* path to device, ie. /sys/class/drm/card#/ */
-	long nv_perf_level; /* The Nvidia Performance Level to adjust */
+	long device; /* path to device, ie. /sys/class/drm/card#/ */
 
 	long nv_core;            /* Nvidia core clock */
 	long nv_mem;             /* Nvidia mem clock */

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -3,6 +3,7 @@ common_sources = [
     'logging.c',
     'governors-query.c',
     'external-helper.c',
+    'gpu-control.c',
 ]
 
 daemon_common = static_library(

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -53,11 +53,8 @@ inhibit_screensaver=1
 ; See NV_CTRL_GPU_POWER_MIZER_MODE and friends in https://github.com/NVIDIA/nvidia-settings/blob/master/src/libXNVCtrl/NVCtrl.h
 ;nv_powermizer_mode=1
 
-; This corresponds to the performance level to edit in nvidia-xconfig
-; Set this to the highest level shown in the nvidia settings power mizer settings
-; Or from the command line check the highest perf value listed by "nvidia-settings -q [gpu:0]/GPUPerfModes"
-;nv_perf_level=1
-; (these two are Mhz offsets from the baseline, ie. 0 applies no change)
+; These will modify the core and mem clocks of the highest perf state in the Nvidia PowerMizer
+; They are measured as Mhz offsets from the baseline, 0 will reset values to default, -1 or unset will not modify values
 ;nv_core_clock_mhz_offset=0
 ;nv_mem_clock_mhz_offset=0
 

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -49,7 +49,8 @@ inhibit_screensaver=1
 ; Nvidia specific settings
 ; Requires the coolbits extension activated in nvidia-xconfig
 ; This corresponds to the desired GPUPowerMizerMode
-; Generally "Adaptive"=0 "Prefer Maximum Performance"=1 and "Auto"=2)
+; "Adaptive"=0 "Prefer Maximum Performance"=1 and "Auto"=2
+; See NV_CTRL_GPU_POWER_MIZER_MODE and friends in https://github.com/NVIDIA/nvidia-settings/blob/master/src/libXNVCtrl/NVCtrl.h
 ;nv_powermizer_mode=1
 
 ; This corresponds to the performance level to edit in nvidia-xconfig (usually the highest level - on older cards 1, newer cards can be 4 or higher)

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -53,7 +53,9 @@ inhibit_screensaver=1
 ; See NV_CTRL_GPU_POWER_MIZER_MODE and friends in https://github.com/NVIDIA/nvidia-settings/blob/master/src/libXNVCtrl/NVCtrl.h
 ;nv_powermizer_mode=1
 
-; This corresponds to the performance level to edit in nvidia-xconfig (usually the highest level - on older cards 1, newer cards can be 4 or higher)
+; This corresponds to the performance level to edit in nvidia-xconfig
+; Set this to the highest level shown in the nvidia settings power mizer settings
+; Or from the command line check the highest perf value listed by "nvidia-settings -q [gpu:0]/GPUPerfModes"
 ;nv_perf_level=1
 ; (these two are Mhz offsets from the baseline, ie. 0 applies no change)
 ;nv_core_clock_mhz_offset=0


### PR DESCRIPTION
Expanding on #111 which will now be closed.

This adds more explanation about the nv config options, while also removing the need to specify the `nv_perf_level` attribute, as it was rightly seen to be a little confusing.

This also fixes some instances where the nv clock options weren't set.