### PR TITLE
Try and make an educated guess at the correct nvidia gpu index

### DIFF
--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -397,13 +397,11 @@ int main(int argc, char *argv[])
 		info.device = get_device(argv[1]);
 		info.vendor = gamemode_get_gpu_vendor(info.device);
 
-		/* Adjust the device number to the gpu index for Nvidia */
-		if (info.vendor == Vendor_NVIDIA)
-			info.device = get_gpu_index_id_nv(&info);
-
 		/* Fetch the state and print it out */
 		switch (info.vendor) {
 		case Vendor_NVIDIA:
+			/* Adjust the device number to the gpu index for Nvidia */
+			info.device = get_gpu_index_id_nv(&info);
 
 			if (get_gpu_state_nv(&info) != 0)
 				exit(EXIT_FAILURE);
@@ -435,6 +433,9 @@ int main(int argc, char *argv[])
 			}
 			info.nv_core = get_generic_value(argv[3]);
 			info.nv_mem = get_generic_value(argv[4]);
+
+			/* Adjust the device number to the gpu index for Nvidia */
+			info.device = get_gpu_index_id_nv(&info);
 
 			/* Optional */
 			info.nv_powermizer_mode = -1;


### PR DESCRIPTION
This should hopefully fix issue #113, where the user was in the common situation of having an intel and an nvidia GPU, at card0 and card1 respectively, but the nvidia gpu was [gpu:0] according to the driver.

The original usage of `NV_PCIDEVICE_ATTRIBUTE` proved entirely incorrect, as that value doesn't correlate to the drm device (sorry!).

This at least works for the default cause of single-nv GPU, as well as the case in the issue of intel-nv dual gpu. It also doesn't risk an infinite loop.

I don't have a dual NV gpu system to test on however, but without being able to find an exact answer anywhere on how the gpu number is achieved, this is probably the best guess and at least works for more cases than any code we had before did!