### PR TITLE
Add more compiler warnings and fix the outfall, most importantly ensure strncpy are null terminated

### DIFF
--- a/daemon/dbus_messaging.c
+++ b/daemon/dbus_messaging.c
@@ -269,21 +269,21 @@ int game_mode_inhibit_screensaver(bool inhibit)
 	const char *function = inhibit ? "Inhibit" : "UnInhibit";
 
 	sd_bus_message *msg = NULL;
-	sd_bus *bus = NULL;
+	sd_bus *bus_local = NULL;
 	sd_bus_error err;
 	memset(&err, 0, sizeof(sd_bus_error));
 
 	int result = -1;
 
 	// Open the user bus
-	int ret = sd_bus_open_user(&bus);
+	int ret = sd_bus_open_user(&bus_local);
 	if (ret < 0) {
 		LOG_ERROR("Could not connect to user bus: %s\n", strerror(-ret));
 		return -1;
 	}
 
 	if (inhibit) {
-		ret = sd_bus_call_method(bus,
+		ret = sd_bus_call_method(bus_local,
 		                         service,
 		                         object_path,
 		                         interface,
@@ -294,7 +294,7 @@ int game_mode_inhibit_screensaver(bool inhibit)
 		                         "com.feralinteractive.GameMode",
 		                         "GameMode Activated");
 	} else {
-		ret = sd_bus_call_method(bus,
+		ret = sd_bus_call_method(bus_local,
 		                         service,
 		                         object_path,
 		                         interface,
@@ -329,6 +329,8 @@ int game_mode_inhibit_screensaver(bool inhibit)
 	} else {
 		result = 0;
 	}
+
+	sd_bus_unref(bus_local);
 
 	return result;
 }

--- a/daemon/dbus_messaging.h
+++ b/daemon/dbus_messaging.h
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 /**
  * Run the main D-BUS loop "forever"
  */
-void game_mode_context_loop(GameModeContext *context);
+void game_mode_context_loop(GameModeContext *context) __attribute__ ((noreturn));
 
 /**
  * Inhibit the screensaver

--- a/daemon/external-helper.c
+++ b/daemon/external-helper.c
@@ -133,7 +133,7 @@ int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFF
 	if (!WIFEXITED(status)) {
 		LOG_ERROR("Child process '%s' exited abnormally\n", exec_args[0]);
 	} else if (WEXITSTATUS(status) != 0) {
-		LOG_ERROR("External process failed with exit code %u\n", WEXITSTATUS(status));
+		LOG_ERROR("External process failed with exit code %d\n", WEXITSTATUS(status));
 		LOG_ERROR("Output was: %s\n", buffer ? buffer : internal);
 		return -1;
 	}

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -224,7 +224,8 @@ int game_mode_get_gpu(GameModeGPUInfo *info)
 		}
 		break;
 	case Vendor_AMD:
-		strncpy(info->amd_performance_level, buffer, CONFIG_VALUE_MAX);
+		strncpy(info->amd_performance_level, buffer, sizeof (info->amd_performance_level) - 1);
+		info->amd_performance_level[sizeof (info->amd_performance_level) - 1] = '\0';
 		break;
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -323,7 +323,7 @@ static int run_cpu_governor_tests(struct GameModeConfig *config)
 	if (defaultgov[0] == '\0') {
 		const char *currentgov = get_gov_state();
 		if (currentgov) {
-			strncpy(defaultgov, currentgov, CONFIG_VALUE_MAX);
+			strncpy(defaultgov, currentgov, CONFIG_VALUE_MAX - 1);
 		} else {
 			LOG_ERROR(
 			    "Could not get current CPU governor state, this indicates an error! See rest "
@@ -445,16 +445,16 @@ int run_gpu_optimisation_tests(struct GameModeConfig *config)
 	long expected_core = gpuinfo->nv_core;
 	long expected_mem = gpuinfo->nv_mem;
 	long expected_nv_powermizer_mode = gpuinfo->nv_powermizer_mode;
-	char expected_amd_performance_level[CONFIG_VALUE_MAX];
-	strncpy(expected_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
+	char expected_amd_performance_level[CONFIG_VALUE_MAX] = { 0 };
+	strncpy(expected_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX - 1);
 
 	/* Get current stats */
 	game_mode_get_gpu(gpuinfo);
 	long original_nv_core = gpuinfo->nv_core;
 	long original_nv_mem = gpuinfo->nv_mem;
 	long original_nv_powermizer_mode = gpuinfo->nv_powermizer_mode;
-	char original_amd_performance_level[CONFIG_VALUE_MAX];
-	strncpy(original_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX);
+	char original_amd_performance_level[CONFIG_VALUE_MAX] = { 0 };
+	strncpy(original_amd_performance_level, gpuinfo->amd_performance_level, CONFIG_VALUE_MAX - 1);
 
 	/* account for when settings are not set */
 	if (expected_nv_powermizer_mode == -1)

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -705,7 +705,7 @@ static int run_supervisor_tests(void)
  *
  * returns 0 for success, -1 for failure
  */
-int game_mode_run_client_tests()
+int game_mode_run_client_tests(void)
 {
 	int status = 0;
 

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -632,7 +632,7 @@ static void *game_mode_context_reaper(void *userdata)
 	return NULL;
 }
 
-GameModeContext *game_mode_context_instance()
+GameModeContext *game_mode_context_instance(void)
 {
 	return &instance;
 }

--- a/daemon/governors-query.c
+++ b/daemon/governors-query.c
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "governors-query.h"
 #include "logging.h"
 
+#include <assert.h>
 #include <glob.h>
 #include <stdio.h>
 #include <string.h>
@@ -80,12 +81,13 @@ int fetch_governors(char governors[MAX_GOVERNORS][MAX_GOVERNOR_LENGTH])
 
 		/* Only add this governor if it is unique */
 		for (int j = 0; j < num_governors; j++) {
-			if (strncmp(fullpath, governors[i], MAX_GOVERNOR_LENGTH) == 0) {
+			if (strncmp(fullpath, governors[i], PATH_MAX) == 0) {
 				continue;
 			}
 		}
 
 		/* Copy this governor into the output set */
+		static_assert(MAX_GOVERNOR_LENGTH > PATH_MAX, "possible string truncation");
 		strncpy(governors[num_governors], fullpath, MAX_GOVERNOR_LENGTH);
 		num_governors++;
 	}

--- a/daemon/governors-query.c
+++ b/daemon/governors-query.c
@@ -134,7 +134,7 @@ const char *get_gov_state(void)
 				return "malformed";
 			}
 
-			strncpy(governor, contents, sizeof(governor));
+			strncpy(governor, contents, sizeof(governor) - 1);
 		} else {
 			LOG_ERROR("Failed to read contents of %s\n", gov);
 		}

--- a/daemon/gpu-control.c
+++ b/daemon/gpu-control.c
@@ -62,9 +62,9 @@ enum GPUVendor gamemode_get_gpu_vendor(long device)
 		LOG_ERROR("Unknown vendor value (0x%04x) found, cannot apply optimisations!\n",
 		          (unsigned int)vendor);
 		LOG_ERROR("Known values are: 0x%04x (NVIDIA) 0x%04x (AMD) 0x%04x (Intel)\n",
-		          Vendor_NVIDIA,
-		          Vendor_AMD,
-		          Vendor_Intel);
+		          (unsigned int)Vendor_NVIDIA,
+		          (unsigned int)Vendor_AMD,
+		          (unsigned int)Vendor_Intel);
 		return Vendor_Invalid;
 	}
 

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -414,7 +414,7 @@ int main(int argc, char *argv[])
 			break;
 		default:
 			LOG_ERROR("Currently unsupported GPU vendor 0x%04x, doing nothing!\n",
-			          (short)info.vendor);
+			          (unsigned short)info.vendor);
 			break;
 		}
 
@@ -454,7 +454,7 @@ int main(int argc, char *argv[])
 			break;
 		default:
 			LOG_ERROR("Currently unsupported GPU vendor 0x%04x, doing nothing!\n",
-			          (short)info.vendor);
+			          (unsigned short)info.vendor);
 			print_usage_and_exit();
 			break;
 		}

--- a/daemon/gpuclockctl.c
+++ b/daemon/gpuclockctl.c
@@ -289,7 +289,7 @@ static int get_gpu_state_amd(struct GameModeGPUInfo *info)
 		return -1;
 	}
 
-	char buff[CONFIG_VALUE_MAX];
+	char buff[CONFIG_VALUE_MAX] = { 0 };
 	if (!fgets(buff, CONFIG_VALUE_MAX, file)) {
 		LOG_ERROR("Could not read file %s (%s)!\n", path, strerror(errno));
 		return -1;
@@ -301,8 +301,8 @@ static int get_gpu_state_amd(struct GameModeGPUInfo *info)
 	}
 
 	/* Copy in the value from the file */
-	strncpy(info->amd_performance_level, buff, CONFIG_VALUE_MAX);
-
+	strncpy(info->amd_performance_level, buff, CONFIG_VALUE_MAX-1);
+	info->amd_performance_level[CONFIG_VALUE_MAX-1] = '\0';
 	return info == NULL;
 }
 
@@ -449,7 +449,7 @@ int main(int argc, char *argv[])
 				LOG_ERROR("Must pass performance level for AMD gpu!\n");
 				print_usage_and_exit();
 			}
-			strncpy(info.amd_performance_level, argv[3], CONFIG_VALUE_MAX);
+			strncpy(info.amd_performance_level, argv[3], CONFIG_VALUE_MAX - 1);
 			return set_gpu_state_amd(&info);
 			break;
 		default:

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,54 @@ add_global_arguments(am_cflags, language: 'c')
 
 cc = meson.get_compiler('c')
 
+# additional compiler warnings, if supported
+test_args = [
+  '-Waggregate-return',
+  '-Wunused',
+  '-Warray-bounds',
+  '-Wcast-align',
+  '-Wclobbered',
+  '-Wempty-body',
+  '-Wformat=2',
+  '-Wformat-nonliteral',
+  '-Wformat-signedness',
+  '-Wignored-qualifiers',
+  '-Wimplicit-function-declaration',
+  '-Winit-self',
+  '-Wmissing-format-attribute',
+  '-Wmissing-include-dirs',
+  '-Wmissing-noreturn',
+  '-Wmissing-parameter-type',
+  '-Wnested-externs',
+  '-Wno-discarded-qualifiers',
+  '-Wno-missing-field-initializers',
+  '-Wno-suggest-attribute=format',
+  '-Wno-unused-parameter',
+  '-Wold-style-definition',
+  '-Woverride-init',
+  '-Wpointer-arith',
+  '-Wredundant-decls',
+  '-Wreturn-type',
+  '-Wshadow',
+  '-Wsign-compare',
+  '-Wstrict-aliasing=3',
+  '-Wstrict-prototypes',
+  '-Wstringop-overflow',
+  '-Wstringop-truncation',
+  '-Wtype-limits',
+  '-Wundef',
+  '-Wuninitialized',
+  '-Wunused-but-set-variable',
+  '-Wwrite-strings',
+]
+
+foreach arg: test_args
+  if cc.has_argument(arg)
+    add_global_arguments(arg, language : 'c')
+  endif
+endforeach
+
+
 path_prefix = get_option('prefix')
 path_bindir = join_paths(path_prefix, get_option('bindir'))
 path_datadir = join_paths(path_prefix, get_option('datadir'))


### PR DESCRIPTION
Add some additional compiler warnings to catch more potential issues. `-Wstringop-truncation` lead to a few new warnings, some false positives, but I believe not all. I included some changes to make absolutely sure and obvious that all strings are properly null terminated. `'-Wshadow'` complained about `bus` being shadowed in `game_mode_inhibit_screensaver` and I spotted that the local `bus` was not unref'ed. `-Wformat-signedness` lead to a fixes for a few format strings. I have some cleanup patches for `inih` as well.