### PR TITLE
Use path_bindir for installing gamemoderun

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -42,7 +42,7 @@ configure_file(
     input: 'gamemoderun.in',
     output: 'gamemoderun',
     configuration: data_conf,
-    install_dir: 'bin',
+    install_dir: path_bindir,
     install_mode: 'rwxr-xr-x',
 )
 


### PR DESCRIPTION
Honor prefix for installing gamemoderun to properly work in cross
environment so it can be installed in e.g. /usr/x86_64-pc-linux-gnu/bin
instead of /usr/bin like it's already done for gamemoded.