### PR TITLE
Introduce a ClientCount dbus Property

### DIFF
--- a/daemon/dbus_messaging.h
+++ b/daemon/dbus_messaging.h
@@ -44,3 +44,8 @@ void game_mode_context_loop(GameModeContext *context) __attribute__((noreturn));
  * Inhibit the screensaver
  */
 int game_mode_inhibit_screensaver(bool inhibit);
+
+/**
+ * Signal the ClientCount property has changed
+ */
+void game_mode_client_count_changed(void);

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -89,7 +89,6 @@ static volatile bool had_context_init = false;
 static GameModeClient *game_mode_client_new(pid_t pid, char *exe);
 static void game_mode_client_free(GameModeClient *client);
 static const GameModeClient *game_mode_context_has_client(GameModeContext *self, pid_t client);
-static int game_mode_context_num_clients(GameModeContext *self);
 static void *game_mode_context_reaper(void *userdata);
 static void game_mode_context_enter(GameModeContext *self);
 static void game_mode_context_leave(GameModeContext *self);
@@ -316,10 +315,7 @@ static const GameModeClient *game_mode_context_has_client(GameModeContext *self,
 	return found;
 }
 
-/**
- * Helper to grab the current number of clients we know about
- */
-static int game_mode_context_num_clients(GameModeContext *self)
+int game_mode_context_num_clients(GameModeContext *self)
 {
 	return atomic_load(&self->refcount);
 }

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -415,6 +415,8 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 	/* Apply io priorities */
 	game_mode_apply_ioprio(self, client);
 
+	game_mode_client_count_changed();
+
 	return 0;
 
 error_cleanup:
@@ -497,6 +499,8 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 	if (atomic_fetch_sub_explicit(&self->refcount, 1, memory_order_seq_cst) == 1) {
 		game_mode_context_leave(self);
 	}
+
+	game_mode_client_count_changed();
 
 	return 0;
 }

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -64,6 +64,13 @@ void game_mode_context_init(GameModeContext *self);
 void game_mode_context_destroy(GameModeContext *self);
 
 /**
+ * Query the number of currently registered clients.
+ *
+ * @returns The number of clients. A number > 0 means that gamemode is active.
+ */
+int game_mode_context_num_clients(GameModeContext *self);
+
+/**
  * Register a new game client with the context
  *
  * @param pid Process ID for the remote client


### PR DESCRIPTION
I want to write a simple GNOME shell extension that displays an icon if gamemode is active (maybe in the future a list of games requestion game mode as a menu would be nice too). For this a property that can be watched would be neat. 