### PR TITLE
Add reference to openSUSE packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Issues with GameMode should be reported here in the issues section, and not repo
 ---
 ## Building and installing [![Build Status](https://travis-ci.org/FeralInteractive/gamemode.svg?branch=master)](https://travis-ci.org/FeralInteractive/gamemode)
 
-*It is preferable to install GameMode with your package manager of choice, if available*. There are Ubuntu (Cosmic), Debian, Solus, AUR, Gentoo and Fedora packages available at the time of writing.
+*It is preferable to install GameMode with your package manager of choice, if available*. There are Ubuntu (Cosmic), Debian, Solus, AUR, Gentoo, Fedora and openSUSE packages available at the time of writing.
 
 ### Install Dependencies
 GameMode depends on `meson` for building and `systemd` for internal communication. This repo contains a `bootstrap.sh` script to allow for quick install to the user bus, but check `meson_options.txt` for custom settings.


### PR DESCRIPTION
OpenSUSE packages are available at https://software.opensuse.org/package/gamemode, so let's reflect this in the README.