### PR TITLE
[Draft] Add Hybrid GPU and environment variable functionality to gamemoderun

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -94,6 +94,9 @@ struct GameModeConfig {
 		long nv_powermizer_mode;
 		char amd_performance_level[CONFIG_VALUE_MAX];
 
+		char vsync_mode[CONFIG_VALUE_MAX];
+		char hybrid_gpu_mode[CONFIG_VALUE_MAX];
+
 		long require_supervisor;
 		char supervisor_whitelist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		char supervisor_blacklist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
@@ -261,6 +264,13 @@ static int inih_handler(void *user, const char *section, const char *name, const
 		} else if (strcmp(name, "amd_performance_level") == 0) {
 			valid = get_string_value(value, self->values.amd_performance_level);
 		}
+	} else if (strcmp(section, "gamemoderun") == 0) {
+		/* gamemoderun subsection */
+		if (strcmp(name, "vsync_mode") == 0) {
+			valid = get_string_value(value, self->values.vsync_mode);
+		} else if (strcmp(name, "hybrid_gpu_mode") == 0) {
+			valid = get_string_value(value, self->values.hybrid_gpu_mode);
+		}
 	} else if (strcmp(section, "supervisor") == 0) {
 		/* Supervisor subsection */
 		if (strcmp(name, "supervisor_whitelist") == 0) {
@@ -354,7 +364,7 @@ static void load_config_files(GameModeConfig *self)
 		if (locations[i].path && asprintf(&path, "%s/" CONFIG_NAME, locations[i].path) > 0) {
 			FILE *f = fopen(path, "r");
 			if (f) {
-				LOG_MSG("Loading config file [%s]\n", path);
+				// LOG_MSG("Loading config file [%s]\n", path);
 				load_protected = locations[i].protected;
 				int error = ini_parse_file(f, inih_handler, (void *)self);
 
@@ -578,18 +588,44 @@ void config_get_apply_gpu_optimisations(GameModeConfig *self, char value[CONFIG_
 	                     sizeof(self->values.apply_gpu_optimisations));
 }
 
-/* Define the getters for GPU values */
+/* Define getter for GPU index */
 DEFINE_CONFIG_GET(gpu_device)
+
+/*
+ * Define getters for nvidia settings
+ */
 DEFINE_CONFIG_GET(nv_core_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_mem_clock_mhz_offset)
 DEFINE_CONFIG_GET(nv_powermizer_mode)
 
+/*
+ * Get AMD performance level
+ */
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
 {
 	memcpy_locked_config(self,
 	                     value,
 	                     &self->values.amd_performance_level,
 	                     sizeof(self->values.amd_performance_level));
+}
+
+/*
+ * Get vsync mode
+ */
+void config_get_vsync_mode(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self, value, &self->values.vsync_mode, sizeof(self->values.vsync_mode));
+}
+
+/*
+ * Get hybrid GPU mode
+ */
+void config_get_hybrid_gpu_mode(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self,
+	                     value,
+	                     &self->values.hybrid_gpu_mode,
+	                     sizeof(self->values.hybrid_gpu_mode));
 }
 
 /*

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -145,9 +145,15 @@ long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_powermizer_mode(GameModeConfig *self);
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
 
-/**
+/*
  * Functions to get supervisor config permissions
  */
 long config_get_require_supervisor(GameModeConfig *self);
 bool config_get_supervisor_whitelisted(GameModeConfig *self, const char *supervisor);
 bool config_get_supervisor_blacklisted(GameModeConfig *self, const char *supervisor);
+
+/*
+ * Get values for gamemoderun
+ */
+void config_get_vsync_mode(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
+void config_get_hybrid_gpu_mode(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -706,3 +706,15 @@ static void game_mode_execute_scripts(char scripts[CONFIG_LIST_MAX][CONFIG_VALUE
 		i++;
 	}
 }
+
+void return_vsync_mode(GameModeContext *self, char vsync_mode[CONFIG_VALUE_MAX])
+{
+	GameModeConfig *config = game_mode_config_from_context(self);
+	config_get_vsync_mode(config, vsync_mode);
+}
+
+void return_hybrid_gpu_mode(GameModeContext *self, char hybrid_gpu_mode[CONFIG_VALUE_MAX])
+{
+	GameModeConfig *config = game_mode_config_from_context(self);
+	config_get_hybrid_gpu_mode(config, hybrid_gpu_mode);
+}

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -34,6 +34,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stdbool.h>
 #include <sys/types.h>
 
+#include "daemon_config.h"
+
 #define INVALID_PROCFD -1
 
 typedef int procfd_t;
@@ -152,3 +154,9 @@ int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info);
 void game_mode_free_gpu(GameModeGPUInfo **info);
 int game_mode_apply_gpu(const GameModeGPUInfo *info);
 int game_mode_get_gpu(GameModeGPUInfo *info);
+
+/**
+ * Return functions for gamemoderun
+ */
+void return_vsync_mode(GameModeContext *self, char vsync_mode[CONFIG_VALUE_MAX]);
+void return_hybrid_gpu_mode(GameModeContext *self, char hybrid_gpu_mode[CONFIG_VALUE_MAX]);

--- a/data/gamemoderun.in
+++ b/data/gamemoderun.in
@@ -1,11 +1,6 @@
 #!/bin/bash
 # Helper script to launch games with gamemode
 
-# Path to install gamemoded auto script
-CONFIG_LIB_DIR="@GAMEMODE_LIB_DIR@/libgamemodeauto.so.0"
-
-# Set the ld preload path prefixed libgamemodeauto
-export LD_PRELOAD="${CONFIG_LIB_DIR}${LD_PRELOAD:+:$LD_PRELOAD}"
-
-# Launch
-exec "$@"
+exec_cmd="$(gamemoded -e)"
+echo "gamemoderun: launch with $exec_cmd"
+$exec_cmd "$@"

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,7 +1,6 @@
 data_conf = configuration_data()
 data_conf.set('BINDIR', path_bindir)
 data_conf.set('LIBEXECDIR', path_libexecdir)
-data_conf.set('GAMEMODE_LIB_DIR', path_libdir)
 
 # Pull in the example config
 config_example = run_command(

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -66,6 +66,17 @@ inhibit_screensaver=1
 ; This corresponds to power_dpm_force_performance_level, "manual" is not supported for now
 ;amd_performance_level=high
 
+[gamemoderun]
+; This section is for settings which will only work if the application is started with gamemoderun
+
+; Force a vsync mode
+; Allowed options: none, force_disable, force_enable
+;vsync_mode=none
+
+; Hybrid GPU settings
+; Allowed options: prime, bumblebee, primus, nvidia-xrun
+;hybrid_gpu_mode=none
+
 [supervisor]
 ; This section controls the new gamemode functions gamemode_request_start_for and gamemode_request_end_for
 ; The whilelist and blacklist control which supervisor programs are allowed to make the above requests

--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,7 @@ with_examples = get_option('with-examples')
 cdata = configuration_data()
 cdata.set_quoted('LIBEXECDIR', path_libexecdir)
 cdata.set_quoted('GAMEMODE_VERSION', meson.project_version())
+cdata.set_quoted('GAMEMODE_LIB_DIR', path_libdir)
 config_h = configure_file(
     configuration: cdata,
     output: 'config.h',


### PR DESCRIPTION
This adds the functionality to run games started with gamemoderun on a secondary gpu, and also makes it easy to implement additional functionality to gamemoderun, which can only be controlled before the game is started.

The code is mostly ready, but to make this work we need a clean output if calling `gamemoded -e`.
At the moment I achieve this by removing the line where the config is loaded. Since this is a information that's sometimes useful, a workaround for this is required.

This closes #20 and needs a rewriting of #87.