### PR TITLE
lib: release acquired bus reference

### DIFF
--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -92,6 +92,7 @@ static int gamemode_request(const char *function, int arg)
 				         strerror(-ret));
 			}
 		}
+		sd_bus_unref(bus);
 	}
 
 	return result;


### PR DESCRIPTION
On each `gamemode_request` call a new connection to d-bus is opened but the reference was never release thus leaking the connection and associated memory.