### PR TITLE
Use readlink instead of realpath so find_exe works for flatpaks

### DIFF
--- a/daemon/helpers.c
+++ b/daemon/helpers.c
@@ -1,0 +1,41 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+Copyright (c) 2019, Red Hat
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#define _GNU_SOURCE
+#include "helpers.h"
+
+/* Starting with C99 we can use "inline" without "static" and thus avoid
+ * having multiple (local) definitions of the same inline function. One
+ * consequence of that is that if the compiler decides to *not* inline
+ * a specific call to the function the linker will expect an definition.
+ */
+extern inline void cleanup_close(int *fd);

--- a/daemon/helpers.h
+++ b/daemon/helpers.h
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <string.h>
 #include <sys/param.h>
+#include <unistd.h>
 
 /**
  * Value clamping helper, works like MIN/MAX but constraints a value within the range.
@@ -62,3 +63,21 @@ static inline const char *strtail(const char *haystack, const char *needle)
 		return pos;
 	return NULL;
 }
+
+/**
+ * Helper function for autoclosing file-descriptors. Does nothing if the argument
+ * is NULL or the referenced integer < 0.
+ */
+inline void cleanup_close(int *fd_ptr)
+{
+	if (fd_ptr == NULL || *fd_ptr < 0)
+		return;
+
+	(void)close(*fd_ptr);
+}
+
+/**
+ * Helper macro for autoclosing file-descriptors: use by prefixing the variable,
+ * like "autoclose_fd int fd = -1;".
+ */
+#define autoclose_fd __attribute__((cleanup(cleanup_close)))

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -30,6 +30,7 @@ daemon_sources = [
     'daemonize.c',
     'dbus_messaging.c',
     'daemon_config.c',
+    'helpers.c',
 ]
 
 gamemoded_includes = libgamemode_includes


### PR DESCRIPTION
Currently to find the executable for a game, a call to realpath(3) of /proc/<pid>/exe is made. The realpath(3) call will fail if the target does not exist (internally realpath will stat all the components of the link target path). This is a problem in the case of sandbox applications where the exe points to the absolute path *inside* the sandbox, e.g. to /app/bin/<name> in the case of flatpak. For these cases realpath(3) will then fail. Therefore use readlink(3) instead.

I have omitted the call to stat for the target because I am not sure it is necessary (and most likely the target will exist, because it just requested gamemode). I can add it though. Also by using readlink(3) we lose the ability to resolve names with `..` components but for our use case that should not matter.