### PR TITLE
ioprio and niceness fixes, and long cmdline options

### DIFF
--- a/daemon/daemon_config.c
+++ b/daemon/daemon_config.c
@@ -548,6 +548,11 @@ long config_get_renice_value(GameModeConfig *self)
 {
 	long value = 0;
 	memcpy_locked_config(self, &value, &self->values.renice, sizeof(long));
+	/* Validate the renice value */
+	if ((value < 1 || value > 20) && value != 0) {
+		LOG_ONCE(ERROR, "Configured renice value '%ld' is invalid, will not renice.\n", value);
+		value = 0;
+	}
 	return value;
 }
 

--- a/daemon/daemon_config.h
+++ b/daemon/daemon_config.h
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
  */
 #define IOPRIO_RESET_DEFAULT -1
 #define IOPRIO_DONT_SET -2
+#define IOPRIO_DEFAULT 4
 
 /*
  * Opaque config context type

--- a/daemon/gamemode-ioprio.c
+++ b/daemon/gamemode-ioprio.c
@@ -188,4 +188,6 @@ void game_mode_apply_ioprio(const GameModeContext *self, const pid_t client, int
 			}
 		}
 	}
+
+	closedir(client_task_dir);
 }

--- a/daemon/gamemode-sched.c
+++ b/daemon/gamemode-sched.c
@@ -121,11 +121,13 @@ void game_mode_apply_renice(const GameModeContext *self, const pid_t client, int
 		/* Clear errno as -1 is a regitimate return */
 		errno = 0;
 		int prio = getpriority(PRIO_PROCESS, (id_t)tid);
+
 		if (prio == -1 && errno) {
-			/* process has likely ended, only log an error if we were actually trying to set a
-			 * non-zero value */
-			if (errno == ESRCH && renice != 0)
-				LOG_ERROR("getpriority returned ESRCH for process %d\n", tid);
+			/* Process may well have ended */
+			LOG_ERROR("getpriority failed for client [%d,%d] with error: %s\n",
+			          client,
+			          tid,
+			          strerror(errno));
 		} else if (prio != expected) {
 			/*
 			 * Don't adjust priority if it does not match the expected value

--- a/daemon/gamemode-sched.c
+++ b/daemon/gamemode-sched.c
@@ -138,7 +138,7 @@ void game_mode_apply_renice(const GameModeContext *self, const pid_t client, int
 			          tid,
 			          prio,
 			          expected);
-		} else if (setpriority(PRIO_PROCESS, (id_t)client, (int)renice)) {
+		} else if (setpriority(PRIO_PROCESS, (id_t)tid, (int)renice)) {
 			LOG_HINTED(ERROR,
 			           "Failed to renice client [%d,%d], ignoring error condition: %s\n",
 			           "    -- Your user may not have permission to do this. Please read the docs\n"

--- a/daemon/gamemode-sched.c
+++ b/daemon/gamemode-sched.c
@@ -148,6 +148,8 @@ void game_mode_apply_renice(const GameModeContext *self, const pid_t client, int
 			           strerror(errno));
 		}
 	}
+
+	closedir(client_task_dir);
 }
 
 void game_mode_apply_scheduling(const GameModeContext *self, const pid_t client)

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -865,9 +865,6 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		}
 	}
 
-	/* Does the screensaver get inhibited? */
-	/* TODO: Unknown if this is testable, org.freedesktop.ScreenSaver has no query method */
-
 	/* Was the process reniced? */
 	{
 		LOG_MSG("::: Verifying renice\n");
@@ -878,9 +875,9 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else if (renicestatus == 0)
 			LOG_MSG("::: Passed\n");
 		else {
-			LOG_MSG("::: Failed! (non-fatal, known issue with multithreaded programs)\n");
+			LOG_MSG("::: Failed!\n");
 			// Renice should be expected to work, if set
-			status = 1;
+			status = -1;
 		}
 	}
 
@@ -899,10 +896,10 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		}
 	}
 
-	/* Was the scheduling applied? */
-	/* Were io priorities changed? */
-	/* Note: These don't get cleared up on un-register, so will have already been applied */
 	/* TODO */
+	/* Was the scheduling applied and removed? Does it get applied to a full process tree? */
+	/* Does the screensaver get inhibited? Unknown if this is testable, org.freedesktop.ScreenSaver
+	 * has no query method */
 
 	if (status != -1)
 		LOG_MSG(":: Passed%s\n\n", status > 0 ? " (with optional failures)" : "");

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -627,6 +627,7 @@ static pid_t run_tests_on_process_tree(int innactive, int active, int (*func)(pi
 			fail |= (active != func(info[i].this));
 		if (fail) {
 			LOG_ERROR("values for threads were not set correctly!\n");
+			gamemode_request_end();
 			exit(-1);
 		}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -874,9 +874,8 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else if (iopriostatus == 0)
 			LOG_MSG("::: Passed\n");
 		else {
-			LOG_MSG(
-			    "::: Failed! (known: https://github.com/FeralInteractive/gamemode/issues/140)\n");
-			status = 1;
+			LOG_MSG("::: Failed!\n");
+			status = -1;
 		}
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -809,7 +809,7 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else {
 			LOG_MSG("::: Failed!\n");
 			// Consider the CPU governor feature required
-			status = 1;
+			status = -1;
 		}
 	}
 
@@ -825,7 +825,7 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else {
 			LOG_MSG("::: Failed!\n");
 			// Any custom scripts should be expected to work
-			status = 1;
+			status = -1;
 		}
 	}
 
@@ -841,7 +841,7 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else {
 			LOG_MSG("::: Failed!\n");
 			// Any custom scripts should be expected to work
-			status = 1;
+			status = -1;
 		}
 	}
 
@@ -860,7 +860,7 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else {
 			LOG_MSG("::: Failed!\n");
 			// Renice should be expected to work, if set
-			status = 1;
+			status = -1;
 		}
 	}
 
@@ -876,7 +876,7 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else {
 			LOG_MSG("::: Failed!\n");
 			// Ioprio should be expected to work, if set
-			status = 1;
+			status = -1;
 		}
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -874,9 +874,9 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 		else if (iopriostatus == 0)
 			LOG_MSG("::: Passed\n");
 		else {
-			LOG_MSG("::: Failed!\n");
-			// Ioprio should be expected to work, if set
-			status = -1;
+			LOG_MSG(
+			    "::: Failed! (known: https://github.com/FeralInteractive/gamemode/issues/140)\n");
+			status = 1;
 		}
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -611,7 +611,7 @@ static pid_t run_process_tree(int innactive, int active, testfunc func)
 			ret ^= func(active, info[i].this);
 
 		if (ret != 0) {
-			LOG_ERROR("Initial ioprio values for new threads were incorrect!\n");
+			LOG_ERROR("Initial values for new threads were incorrect!\n");
 			gamemode_request_end();
 			exit(ret);
 		}
@@ -623,7 +623,7 @@ static pid_t run_process_tree(int innactive, int active, testfunc func)
 		for (unsigned int i = 0; i < numthreads; i++)
 			ret ^= func(innactive, info[i].this);
 		if (ret != 0) {
-			LOG_ERROR("Ioprio values for threads were not reset after gamemode_request_end!\n");
+			LOG_ERROR("values for threads were not reset after gamemode_request_end!\n");
 			exit(ret);
 		}
 
@@ -634,7 +634,7 @@ static pid_t run_process_tree(int innactive, int active, testfunc func)
 		for (unsigned int i = 0; i < numthreads; i++)
 			ret ^= func(active, info[i].this);
 		if (ret != 0) {
-			LOG_ERROR("ioprio values for threads were not set correctly!\n");
+			LOG_ERROR("values for threads were not set correctly!\n");
 			exit(ret);
 		}
 
@@ -645,7 +645,7 @@ static pid_t run_process_tree(int innactive, int active, testfunc func)
 		for (unsigned int i = 0; i < numthreads; i++)
 			ret ^= func(innactive, info[i].this);
 		if (ret != 0) {
-			LOG_ERROR("Ioprio values for threads were not reset after gamemode_request_end!\n");
+			LOG_ERROR("values for threads were not reset after gamemode_request_end!\n");
 			exit(ret);
 		}
 

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -513,6 +513,9 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 
 	game_mode_client_count_changed();
 
+	/* Restore the ioprio value for the process, expecting it to be the config value  */
+	game_mode_apply_ioprio(self, client, (int)config_get_ioprio_value(self->config));
+
 	/* Restore the renice value for the process, expecting it to be our config value */
 	game_mode_apply_renice(self, client, (int)config_get_renice_value(self->config));
 

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -71,9 +71,6 @@ struct GameModeContext {
 	struct GameModeGPUInfo *stored_gpu; /**<Stored GPU info for the current GPU */
 	struct GameModeGPUInfo *target_gpu; /**<Target GPU info for the current GPU */
 
-	int initial_renice; /**<Initial renice value */
-	int initial_ioprio; /**<Initial ioprio value */
-
 	/* Reaper control */
 	struct {
 		pthread_t thread;
@@ -416,11 +413,9 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 	}
 
 	/* Store current renice and apply */
-	self->initial_renice = game_mode_get_renice(client);
 	game_mode_apply_renice(self, client, 0 /* expect zero value to start with */);
 
 	/* Store current ioprio value and apply  */
-	self->initial_ioprio = game_mode_get_ioprio(client);
 	game_mode_apply_ioprio(self, client, IOPRIO_DEFAULT);
 
 	/* Apply scheduler policies */

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -72,6 +72,7 @@ struct GameModeContext {
 	struct GameModeGPUInfo *target_gpu; /**<Target GPU info for the current GPU */
 
 	int initial_renice; /**<Initial renice value */
+	int initial_ioprio; /**<Initial ioprio value */
 
 	/* Reaper control */
 	struct {
@@ -418,11 +419,12 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 	self->initial_renice = game_mode_get_renice(client);
 	game_mode_apply_renice(self, client, 0 /* expect zero value to start with */);
 
+	/* Store current ioprio value and apply  */
+	self->initial_ioprio = game_mode_get_ioprio(client);
+	game_mode_apply_ioprio(self, client, IOPRIO_DEFAULT);
+
 	/* Apply scheduler policies */
 	game_mode_apply_scheduling(self, client);
-
-	/* Apply io priorities */
-	game_mode_apply_ioprio(self, client);
 
 	game_mode_client_count_changed();
 

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -71,6 +71,8 @@ struct GameModeContext {
 	struct GameModeGPUInfo *stored_gpu; /**<Stored GPU info for the current GPU */
 	struct GameModeGPUInfo *target_gpu; /**<Target GPU info for the current GPU */
 
+	int initial_renice; /**<Initial renice value */
+
 	/* Reaper control */
 	struct {
 		pthread_t thread;
@@ -412,8 +414,11 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 		game_mode_context_enter(self);
 	}
 
+	/* Store current renice and apply */
+	self->initial_renice = game_mode_get_renice(client);
+	game_mode_apply_renice(self, client, 0 /* expect zero value to start with */);
+
 	/* Apply scheduler policies */
-	game_mode_apply_renice(self, client);
 	game_mode_apply_scheduling(self, client);
 
 	/* Apply io priorities */

--- a/daemon/gamemode.c
+++ b/daemon/gamemode.c
@@ -511,6 +511,9 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 
 	game_mode_client_count_changed();
 
+	/* Restore the renice value for the process, expecting it to be our config value */
+	game_mode_apply_renice(self, client, (int)config_get_renice_value(self->config));
+
 	return 0;
 }
 

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -135,7 +135,8 @@ int game_mode_close_proc(const procfd_t procfd);
  * Provides internal API functions specific to adjusting process
  * scheduling.
  */
-void game_mode_apply_renice(const GameModeContext *self, const pid_t client);
+int game_mode_get_renice(const pid_t client);
+void game_mode_apply_renice(const GameModeContext *self, const pid_t client, int expected);
 void game_mode_apply_scheduling(const GameModeContext *self, const pid_t client);
 
 /** gamemode-wine.c

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -122,7 +122,8 @@ char *game_mode_lookup_user_home(void);
  * Provides internal API functions specific to adjusting process
  * IO priorities.
  */
-void game_mode_apply_ioprio(const GameModeContext *self, const pid_t client);
+int game_mode_get_ioprio(const pid_t client);
+void game_mode_apply_ioprio(const GameModeContext *self, const pid_t client, int expected);
 
 /** gamemode-proc.c
  * Provides internal API functions specific to working with process

--- a/daemon/helpers.h
+++ b/daemon/helpers.h
@@ -39,7 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 /**
  * Value clamping helper, works like MIN/MAX but constraints a value within the range.
  */
-#define CLAMP(lbound, ubound, value) MIN(MIN(lbound, ubound), MAX(MAX(lbound, ubound), value))
+#define CLAMP(l, u, value) MAX(MIN(l, u), MIN(MAX(l, u), value))
 
 /**
  * Little helper to safely print into a buffer, returns a pointer into the buffer

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -114,7 +114,8 @@ int main(int argc, char *argv[])
 		                                    { "test", no_argument, 0, 't' },
 		                                    { "status", optional_argument, 0, 's' },
 		                                    { "help", no_argument, 0, 'h' },
-		                                    { "version", no_argument, 0, 'v' } };
+		                                    { "version", no_argument, 0, 'v' },
+		                                    { NULL, 0, NULL, 0 }, };
 	static const char *short_options = "dls::r::tvh";
 
 	while ((opt = getopt_long(argc, argv, short_options, long_options, 0)) != -1) {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -108,14 +108,12 @@ int main(int argc, char *argv[])
 	int opt = 0;
 
 	/* Options struct for getopt_long */
-	static struct option long_options[] = { { "daemonize", no_argument, 0, 'd' },
-		                                    { "log-to-syslog", no_argument, 0, 'l' },
-		                                    { "request", optional_argument, 0, 'r' },
-		                                    { "test", no_argument, 0, 't' },
-		                                    { "status", optional_argument, 0, 's' },
-		                                    { "help", no_argument, 0, 'h' },
-		                                    { "version", no_argument, 0, 'v' },
-		                                    { NULL, 0, NULL, 0 }, };
+	static struct option long_options[] = {
+		{ "daemonize", no_argument, 0, 'd' },     { "log-to-syslog", no_argument, 0, 'l' },
+		{ "request", optional_argument, 0, 'r' }, { "test", no_argument, 0, 't' },
+		{ "status", optional_argument, 0, 's' },  { "help", no_argument, 0, 'h' },
+		{ "version", no_argument, 0, 'v' },       { NULL, 0, NULL, 0 },
+	};
 	static const char *short_options = "dls::r::tvh";
 
 	while ((opt = getopt_long(argc, argv, short_options, long_options, 0)) != -1) {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -108,12 +108,13 @@ int main(int argc, char *argv[])
 	int opt = 0;
 
 	/* Options struct for getopt_long */
-	static struct option long_options[] = {
-		{ "daemonize", no_argument, 0, 'd' },     { "log-to-syslog", no_argument, 0, 'l' },
-		{ "request", optional_argument, 0, 'r' }, { "test", no_argument, 0, 't' },
-		{ "status", optional_argument, 0, 's' },  { "help", no_argument, 0, 'h' },
-		{ "version", no_argument, 0, 'v' }
-	};
+	static struct option long_options[] = { { "daemonize", no_argument, 0, 'd' },
+		                                    { "log-to-syslog", no_argument, 0, 'l' },
+		                                    { "request", optional_argument, 0, 'r' },
+		                                    { "test", no_argument, 0, 't' },
+		                                    { "status", optional_argument, 0, 's' },
+		                                    { "help", no_argument, 0, 'h' },
+		                                    { "version", no_argument, 0, 'v' } };
 	static const char *short_options = "dls::r::tvh";
 
 	while ((opt = getopt_long(argc, argv, short_options, long_options, 0)) != -1) {

--- a/data/gamemoded.8.in
+++ b/data/gamemoded.8.in
@@ -14,11 +14,13 @@ The design has a clear cut abstraction between the host daemon and library (\fBg
 .SH OPTIONS
 
 .TP 8
-.B \-r, \-\-request
-Request gamemode and pause
+.B \-r[PID], \-\-request=[PID]
+Toggle gamemode for process.
+When no PID given, requests gamemode and pauses
 .TP 8
-.B \-s, \-\-status
-Query the status of gamemode
+.B \-s[PID], \-\-status=[PID]
+Query the status of gamemode for process
+When no PID given, queries the status globally
 .TP 8
 .B \-d, \-\-daemonize
 Run the daemon as a separate process (daemonize it)

--- a/data/gamemoded.8.in
+++ b/data/gamemoded.8.in
@@ -4,7 +4,7 @@
 .SH NAME
 gamemoded \- optimises system performance on demand
 .SH SYNOPSIS
-\fBgamemoded\fR [\fB\-d\fR] [\fB\-l\fR] [\fB\-h\fR] [\fB\-v\fR]
+\fBgamemoded\fR [OPTIONS...]
 .SH DESCRIPTION
 \fBGameMode\fR is a daemon/lib combo for Linux that allows games to request a set of optimisations be temporarily applied to the host OS.
 
@@ -12,26 +12,27 @@ The design has a clear cut abstraction between the host daemon and library (\fBg
 
 \fBGameMode\fR was designed primarily as a stop-gap solution to problems with the Intel and AMD CPU powersave or ondemand governors, but is intended to be expanded beyond just CPU governor states, as there are a wealth of automation tasks one might want to apply.
 .SH OPTIONS
+
 .TP 8
-.B \-d
+.B \-r, \-\-request
+Request gamemode and pause
+.TP 8
+.B \-s, \-\-status
+Query the status of gamemode
+.TP 8
+.B \-d, \-\-daemonize
 Run the daemon as a separate process (daemonize it)
 .TP 8
-.B \-l
+.B \-l, \-\-log-to-syslog
 Log to syslog
-.TP 8
-.B \-r
-Request gamemode and wait for any signal
-.TP 8
-.B \-s
-Query the current status of gamemode
-.TP 8
-.B \-h
+.TP 8 
+.B \-h, \-\-help
 Print help text
 .TP 8
-.B \-t
+.B \-t, \-\-test
 Run diagnostic tests on the current installation
 .TP 8
-.B \-v
+.B \-v, \-\-version
 Print the version
 
 .SH USAGE

--- a/lib/gamemode_client.h
+++ b/lib/gamemode_client.h
@@ -58,9 +58,11 @@ POSSIBILITY OF SUCH DAMAGE.
  *   -1 if the request failed
  *   -2 if the request was rejected
  *
- * int gamemode_query_status_for(pid_t pid) - Query the current status of gamemode for another
- * process 0 if gamemode is inactive 1 if gamemode is active 2 if gamemode is active and this client
- * is registered -1 if the query failed
+ * int gamemode_query_status_for(pid_t pid) - Query status of gamemode for another process
+ *   0 if gamemode is inactive
+ *   1 if gamemode is active
+ *   2 if gamemode is active and this client is registered
+ *   -1 if the query failed
  *
  * const char* gamemode_error_string() - Get an error string
  *   returns a string describing any of the above errors


### PR DESCRIPTION
This PR has the following changes:

- ioprio and niceness fixes for issue #141 and #140
- support for long command line options, and requesting with `--request=PID` for a specific process

Help now looks like:
```
Usage: gamemoded [-d] [-l] [-r] [-t] [-h] [-v]

  -r[PID], --request=[PID] Toggle gamemode for process
                           When no PID given, requests gamemode and pauses
  -s[PID], --status=[PID]  Query the status of gamemode for process
                           When no PID given, queries the status globally
  -d, --daemonize          Daemonize self after launch
  -l, --log-to-syslog      Log to syslog
  -r, --test               Run tests
  -h, --help               Print this help
  -v, --version            Print version

See man page for more information.
```

I've also implemented tests for the two fixes above, both a302168 and a6e238d can be run to show the tests failing, before the subsequent fixes
