### PR TITLE
added option to disable building the utils

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,6 +125,7 @@ path_polkit_action_dir = join_paths(path_datadir, 'polkit-1', 'actions')
 
 with_daemon = get_option('with-daemon')
 with_examples = get_option('with-examples')
+with_util = get_option('with-util')
 
 # Provide a config.h
 cdata = configuration_data()
@@ -142,8 +143,11 @@ subdir('lib')
 # common lib is always required
 subdir('common')
 
-# Utilities are always required
-subdir('util')
+# Utilities are always required except when having both 64 and 32 bit versions
+# of libgamemode installed
+if with_util == true
+    subdir('util')
+endif
 
 # The daemon can be disabled if necessary, allowing multilib builds of the
 # main library

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,4 @@ option('with-dbus-service-dir', type: 'string', description: 'Explicitly set the
 # General options
 option('with-examples', type: 'boolean', description: 'Build sample programs', value: 'true')
 option('with-daemon', type: 'boolean', description: 'Build the daemon', value: 'true')
+option('with-util', type: 'boolean', description: 'Build the utilities', value: 'true')


### PR DESCRIPTION
When you need both 32 and 64 bit version of the library only one version of the utils is required. I've created an option to disable building the util folder. 
This option is with-util and is by default set to true, so it won't break any normal builds.
