### PR TITLE
Expose registered games on the bus

### DIFF
--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -87,7 +87,6 @@ static GameModeContext instance = { 0 };
 static volatile bool had_context_init = false;
 
 static GameModeClient *game_mode_client_new(pid_t pid, char *exe);
-static void game_mode_client_unref(GameModeClient *client);
 static const GameModeClient *game_mode_context_has_client(GameModeContext *self, pid_t client);
 static void *game_mode_context_reaper(void *userdata);
 static void game_mode_context_enter(GameModeContext *self);
@@ -625,7 +624,7 @@ static GameModeClient *game_mode_client_new(pid_t pid, char *executable)
 /**
  * Unref a client and the next element in the list, if non-null.
  */
-static void game_mode_client_unref(GameModeClient *client)
+void game_mode_client_unref(GameModeClient *client)
 {
 	if (!client) {
 		return;

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -486,6 +486,7 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 	/* Unlock now we're done applying optimisations */
 	pthread_rwlock_unlock(&self->rwlock);
 
+	game_mode_client_registered(client);
 	game_mode_client_count_changed();
 
 	return 0;
@@ -586,6 +587,7 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 	pthread_rwlock_unlock(&self->rwlock);
 
 	game_mode_client_count_changed();
+	game_mode_client_unregistered(client);
 
 	return 0;
 }

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -638,6 +638,14 @@ void game_mode_client_unref(GameModeClient *client)
 	free(client);
 }
 
+void game_mode_client_ref(GameModeClient *client)
+{
+	if (!client) {
+		return;
+	}
+	atomic_fetch_add_explicit(&client->refcount, 1, memory_order_seq_cst);
+}
+
 /* Internal refresh config function (assumes no contention with reaper thread) */
 static void game_mode_reload_config_internal(GameModeContext *self)
 {

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -487,7 +487,6 @@ int game_mode_context_register(GameModeContext *self, pid_t client, pid_t reques
 	pthread_rwlock_unlock(&self->rwlock);
 
 	game_mode_client_registered(client);
-	game_mode_client_count_changed();
 
 	return 0;
 
@@ -586,7 +585,6 @@ int game_mode_context_unregister(GameModeContext *self, pid_t client, pid_t requ
 	/* Unlock now we're done applying optimisations */
 	pthread_rwlock_unlock(&self->rwlock);
 
-	game_mode_client_count_changed();
 	game_mode_client_unregistered(client);
 
 	return 0;

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -51,11 +51,11 @@ POSSIBILITY OF SUCH DAMAGE.
  * The GameModeClient encapsulates the remote connection, providing a list
  * form to contain the pid and credentials.
  */
-typedef struct GameModeClient {
+struct GameModeClient {
 	pid_t pid;                   /**< Process ID */
 	struct GameModeClient *next; /**<Next client in the list */
 	char executable[PATH_MAX];   /**<Process executable */
-} GameModeClient;
+};
 
 struct GameModeContext {
 	pthread_rwlock_t rwlock; /**<Guard access to the client list */

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "build-config.h"
 
+#include <assert.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdatomic.h>
@@ -644,6 +645,24 @@ void game_mode_client_ref(GameModeClient *client)
 		return;
 	}
 	atomic_fetch_add_explicit(&client->refcount, 1, memory_order_seq_cst);
+}
+
+/**
+ * The process identifier of the client.
+ */
+pid_t game_mode_client_get_pid(GameModeClient *client)
+{
+	assert(client != NULL);
+	return client->pid;
+}
+
+/**
+ * The path to the executable of client.
+ */
+const char *game_mode_client_get_executable(GameModeClient *client)
+{
+	assert(client != NULL);
+	return client->executable;
 }
 
 /* Internal refresh config function (assumes no contention with reaper thread) */

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -358,6 +358,29 @@ pid_t *game_mode_context_list_clients(GameModeContext *self, unsigned int *count
 	return res;
 }
 
+GameModeClient *game_mode_context_lookup_client(GameModeContext *self, pid_t client)
+{
+	GameModeClient *found = NULL;
+
+	pthread_rwlock_rdlock(&self->rwlock);
+
+	/* Walk all clients and find a matching pid */
+	for (GameModeClient *cl = self->client; cl; cl = cl->next) {
+		if (cl->pid == client) {
+			found = cl;
+			break;
+		}
+	}
+
+	if (found) {
+		game_mode_client_ref(found);
+	}
+
+	pthread_rwlock_unlock(&self->rwlock);
+
+	return found;
+}
+
 static int game_mode_apply_client_optimisations(GameModeContext *self, pid_t client)
 {
 	/* Store current renice and apply */

--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -203,15 +203,6 @@ static int property_get_client_count(sd_bus *local_bus, const char *path, const 
 	return sd_bus_message_append_basic(reply, 'i', &count);
 }
 
-void game_mode_client_count_changed(void)
-{
-	(void)sd_bus_emit_properties_changed(bus,
-	                                     "/com/feralinteractive/GameMode",
-	                                     "com.feralinteractive.GameMode",
-	                                     "ClientCount",
-	                                     NULL);
-}
-
 /**
  * Handles the Refresh Config request
  */
@@ -293,6 +284,12 @@ static void game_mode_client_send_game_signal(pid_t pid, bool new_game)
 	                         path);
 	if (ret < 0)
 		fprintf(stderr, "failed to emit signal: %s", strerror(-ret));
+
+	(void)sd_bus_emit_properties_changed(bus,
+	                                     "/com/feralinteractive/GameMode",
+	                                     "com.feralinteractive.GameMode",
+	                                     "ClientCount",
+	                                     NULL);
 }
 
 /* Emit GameRegistered signal */

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -197,6 +197,5 @@ int game_mode_get_gpu(GameModeGPUInfo *info);
  */
 void game_mode_context_loop(GameModeContext *context) __attribute__((noreturn));
 int game_mode_inhibit_screensaver(bool inhibit);
-void game_mode_client_count_changed(void);
 void game_mode_client_registered(pid_t);
 void game_mode_client_unregistered(pid_t);

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -198,3 +198,5 @@ int game_mode_get_gpu(GameModeGPUInfo *info);
 void game_mode_context_loop(GameModeContext *context) __attribute__((noreturn));
 int game_mode_inhibit_screensaver(bool inhibit);
 void game_mode_client_count_changed(void);
+void game_mode_client_registered(pid_t);
+void game_mode_client_unregistered(pid_t);

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -96,6 +96,14 @@ void game_mode_context_destroy(GameModeContext *self);
 int game_mode_context_num_clients(GameModeContext *self);
 
 /**
+ * List the currently active clients.
+ * @param out holds the number of active clients.
+ *
+ * @returns A array of pid_t or NULL if there are no active clients.
+ */
+pid_t *game_mode_context_list_clients(GameModeContext *self, unsigned int *count);
+
+/**
  * Register a new game client with the context
  *
  * @param pid Process ID for the remote client

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -43,6 +43,7 @@ typedef int procfd_t;
  */
 typedef struct GameModeContext GameModeContext;
 typedef struct GameModeConfig GameModeConfig;
+typedef struct GameModeClient GameModeClient;
 
 /**
  * Return the singleton instance

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -55,6 +55,11 @@ typedef struct GameModeClient GameModeClient;
 void game_mode_client_unref(GameModeClient *client);
 
 /**
+ * Increment the usage count of client.
+ */
+void game_mode_client_ref(GameModeClient *client);
+
+/**
  * Return the singleton instance
  */
 GameModeContext *game_mode_context_instance(void);

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -46,6 +46,15 @@ typedef struct GameModeConfig GameModeConfig;
 typedef struct GameModeClient GameModeClient;
 
 /**
+ * GameModeClient related functions
+ */
+
+/**
+ * Decrement the usage count of client.
+ */
+void game_mode_client_unref(GameModeClient *client);
+
+/**
  * Return the singleton instance
  */
 GameModeContext *game_mode_context_instance(void);

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -104,6 +104,14 @@ int game_mode_context_num_clients(GameModeContext *self);
 pid_t *game_mode_context_list_clients(GameModeContext *self, unsigned int *count);
 
 /**
+ * Lookup up information about a client via the pid;
+ *
+ * @returns A pointer to a GameModeClient struct or NULL in case no client
+ *           with the corresponding id could be found. Adds a reference to
+ *           GameModeClient that needs to be released.
+ */
+GameModeClient *game_mode_context_lookup_client(GameModeContext *self, pid_t client);
+/**
  * Register a new game client with the context
  *
  * @param pid Process ID for the remote client

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -60,6 +60,16 @@ void game_mode_client_unref(GameModeClient *client);
 void game_mode_client_ref(GameModeClient *client);
 
 /**
+ * The process identifier of the client.
+ */
+pid_t game_mode_client_get_pid(GameModeClient *client);
+
+/**
+ * The path to the executable of client.
+ */
+const char *game_mode_client_get_executable(GameModeClient *client);
+
+/**
  * Return the singleton instance
  */
 GameModeContext *game_mode_context_instance(void);


### PR DESCRIPTION
For the Shell extension (or a little separate tool) as well as future integration with [GNOME Usage](https://gitlab.gnome.org/GNOME/gnome-usage) I wanted to get the list of currently registered games from gamemoded. For this I added to the `com.feralinteractive.GameMode` interface:
```
methods:
  ListGames: Array of Tuples (ProcessId, ObjectPath)

signals:
  GameRegistered: ProcessId, ObjectPath
  GameUnregistered: ProcessId, ObjectPath
```
As well as a new `com.feralinteractive.GameMode.Game` interface:
```
properties:
  ProcessId: int
  Executable: string
```
This should make it possible for a client to track all currently registered games (start listening to the signals, list the current active ones and track changes via the signals). 

In order to expose the individual games, I opted for expose the `GameModeClient` struct (as an opaque struct with getters). To be able to do this I added reference counting to it, so it can outlive being reaped by the reaper. Since the object is de-facto immutable this should be sufficient.