### PR TITLE
daemon: properly report error in error case

### DIFF
--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -257,7 +257,7 @@ static int method_list_games(sd_bus_message *m, void *userdata,
 	free(clients);
 
 	if (r < 0)
-		return 0;
+		return r;
 
 	r = sd_bus_message_close_container(reply);
 	if (r < 0)

--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -468,7 +468,7 @@ static const sd_bus_vtable game_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("ProcessId", "i", game_object_get_process_id, 0,
 	                SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("Exectuable", "s", game_object_get_executable, 0,
+	SD_BUS_PROPERTY("Executable", "s", game_object_get_executable, 0,
 	                SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_VTABLE_END
 };


### PR DESCRIPTION
Currently, in method_list_games (`ListGames` on the bus), when `sd_bus_message_append` fails, we break the loop but then we were not reporting the error (contained in `r`) back to call.