### PR TITLE
Add hybrid GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Config files are loaded and merged from the following directories, in order:
 4. `$PWD`
 
 ---
+## Note for Hybrid GPU users
+
+It's not possible to integrate commands like optirun automatically inside GameMode, since GameMode only starts if the game is already started.
+However it is possible to use a hybrid GPU wrapper like optirun by starting the game with gamemoderun.
+You can do this by setting the environment variable `GAMEMODERUNEXEC` to your wrapper's launch command, so for example `GAMEMODERUNEXEC=optirun` or `GAMEMODERUN="env DRI_PRIME=1"`.
+GameMode will not be injected to the wrapper.
+
+---
 ## Apps with GameMode integration
 
 ### Games

--- a/data/gamemoded.8.in
+++ b/data/gamemoded.8.in
@@ -56,6 +56,12 @@ The library can be manually preloaded if needed:
 LD_PRELOAD=$LD_PRELOAD:/usr/\e$LIB/libgamemodeauto.so.0 ./game
 .RE
 
+It is possible to set additional start commands to gamemoderun by setting the environment variable:
+
+.RS 4
+GAMEMODERUNEXEC="command"
+.RE
+
 The \fBgamemode_client.h\fR header can be used by developers to build the requests into a program:
 
 .RS 4

--- a/data/gamemoderun.in
+++ b/data/gamemoderun.in
@@ -5,6 +5,6 @@
 # appropriate path depending on whether the app is 32- or 64-bit.
 GAMEMODEAUTO="@GAMEMODE_PREFIX@/\$LIB/libgamemodeauto.so.0"
 
-export LD_PRELOAD="${GAMEMODEAUTO}${LD_PRELOAD:+:$LD_PRELOAD}"
+LD_PRELOAD="${GAMEMODEAUTO}${LD_PRELOAD:+:$LD_PRELOAD}"
 
-exec "$@"
+exec $GAMEMODERUNEXEC env LD_PRELOAD="${LD_PRELOAD}" "$@"


### PR DESCRIPTION
I added hybrid GPU support by adding ```$GAMEMODERUNEXEC``` to the gamemoderun launch command. If ```GAMEMODERUNEXEC``` is unset, which given by its very specific name always should be the case by default, the program will execute normal. However if you set the environment variable to a specific command like ```optirun```, it will start optirun, which starts the game.
Since the script injects libgamemodeauto globally inside the script, it will inject GameMode to the wrapper as well as the game. If a wrapper is not important for the performance (like ```env XY=Z```), the user can blacklist it.

closes #20 closes #87 

Signed-off-by: Stephan Lachnit <stephanlachnit@protonmail.com>