### PR TITLE
Add and expose Timestamp and Requester properties for GameModeClient

### DIFF
--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -32,6 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 #define INVALID_PROCFD -1
@@ -68,6 +69,11 @@ pid_t game_mode_client_get_pid(GameModeClient *client);
  * The path to the executable of client.
  */
 const char *game_mode_client_get_executable(GameModeClient *client);
+
+/**
+ * The path to the executable of client.
+ */
+u_int64_t game_mode_client_get_timestamp(GameModeClient *client);
 
 /**
  * Return the singleton instance

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -71,6 +71,11 @@ pid_t game_mode_client_get_pid(GameModeClient *client);
 const char *game_mode_client_get_executable(GameModeClient *client);
 
 /**
+ * The process identifier of the requester.
+ */
+pid_t game_mode_client_get_requester(GameModeClient *client);
+
+/**
  * The path to the executable of client.
  */
 u_int64_t game_mode_client_get_timestamp(GameModeClient *client);

--- a/meson.build
+++ b/meson.build
@@ -198,6 +198,7 @@ report += [
     '',
     '    daemon:                                 @0@'.format(with_daemon),
     '    examples:                               @0@'.format(with_examples),
+    '    util:                                   @0@'.format(with_util),
     '    systemd:                                @0@'.format(with_systemd),
 ]
 


### PR DESCRIPTION
Record the timestamp a client was created and who requested it and expose them as `Timestamp` and `Requester` properties of the `com.feralinteractive.GameMode.Game` interface. I am thinking of creating a small `gamemodeclt` command line tool to show the current status, and list all the clients and all the information we got about them. Maybe also a `gamemodectl -p <pid>` to request GameMode on behalf of `pid`. What do you guys think?