### PR TITLE
Introduce a new pidfd based set of D-Bus APIs

### DIFF
--- a/common/common-helpers.c
+++ b/common/common-helpers.c
@@ -39,3 +39,4 @@ POSSIBILITY OF SUCH DAMAGE.
  * a specific call to the function the linker will expect an definition.
  */
 extern inline void cleanup_close(int *fd);
+extern inline void cleanup_free(void *ptr);

--- a/common/common-helpers.h
+++ b/common/common-helpers.h
@@ -31,6 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
 #include <unistd.h>
@@ -80,3 +81,23 @@ inline void cleanup_close(int *fd_ptr)
  * like "autoclose_fd int fd = -1;".
  */
 #define autoclose_fd __attribute__((cleanup(cleanup_close)))
+
+/**
+ * Helper function for auto-freeing dynamically allocated memory. Does nothing
+ * if *ptr is NULL (ptr must not be NULL).
+ */
+inline void cleanup_free(void *ptr)
+{
+	/* The function is defined to work with 'void *' because
+	 * that will make sure it compiles without warning also
+	 * for all types; what we are getting passed into is a
+	 * pointer to a pointer though, so we need to cast */
+	void *target = *(void **)ptr;
+	free(target); /* free can deal with NULL */
+}
+
+/**
+ * Helper macro for auto-freeing dynamically allocated memory: use by
+ * prefixing the variable, like "autofree char *data = NULL;".
+ */
+#define autofree __attribute__((cleanup(cleanup_free)))

--- a/common/common-pidfds.c
+++ b/common/common-pidfds.c
@@ -1,0 +1,207 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+Copyright (c) 2019, Red Hat
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#define _GNU_SOURCE
+#include <build-config.h>
+
+#include "common-helpers.h"
+#include "common-pidfds.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if !HAVE_FN_PIDFD_OPEN
+#include <sys/syscall.h>
+
+#ifndef __NR_pidfd_open
+#define __NR_pidfd_open 434
+#endif
+
+static int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return (int)syscall(__NR_pidfd_open, pid, flags);
+}
+#endif
+
+/* pidfd functions */
+int open_pidfds(pid_t *pids, int *fds, int count)
+{
+	int i = 0;
+
+	for (i = 0; i < count; i++) {
+		int pid = pids[i];
+		int fd = pidfd_open(pid, 0);
+
+		if (fd < 0)
+			break;
+
+		fds[i] = fd;
+	}
+
+	return i;
+}
+
+static int parse_pid(const char *str, pid_t *pid)
+{
+	unsigned long long int v;
+	char *end;
+	pid_t p;
+
+	errno = 0;
+	v = strtoull(str, &end, 0);
+	if (end == str)
+		return -ENOENT;
+	else if (errno != 0)
+		return -errno;
+
+	p = (pid_t)v;
+
+	if (p < 1 || (unsigned long long int)p != v)
+		return -ERANGE;
+
+	if (pid)
+		*pid = p;
+
+	return 0;
+}
+
+static int parse_status_field_pid(const char *val, pid_t *pid)
+{
+	const char *t;
+
+	t = strrchr(val, '\t');
+	if (t == NULL)
+		return -ENOENT;
+
+	return parse_pid(t, pid);
+}
+
+static int pidfd_to_pid(int fdinfo, int pidfd, pid_t *pid)
+{
+	autofree char *key = NULL;
+	autofree char *val = NULL;
+	char name[256] = {
+		0,
+	};
+	bool found = false;
+	FILE *f = NULL;
+	size_t keylen = 0;
+	size_t vallen = 0;
+	ssize_t n;
+	int fd;
+	int r = 0;
+
+	*pid = 0;
+
+	buffered_snprintf(name, "%d", pidfd);
+
+	fd = openat(fdinfo, name, O_RDONLY | O_CLOEXEC | O_NOCTTY);
+
+	if (fd != -1)
+		f = fdopen(fd, "r");
+
+	if (f == NULL)
+		return -errno;
+
+	do {
+		n = getdelim(&key, &keylen, ':', f);
+		if (n == -1) {
+			r = errno;
+			break;
+		}
+
+		n = getdelim(&val, &vallen, '\n', f);
+		if (n == -1) {
+			r = errno;
+			break;
+		}
+
+		// TODO: strstrip (key);
+
+		if (!strncmp(key, "Pid", 3)) {
+			r = parse_status_field_pid(val, pid);
+			found = r > -1;
+		}
+
+	} while (r == 0 && !found);
+
+	fclose(f);
+
+	if (r < 0)
+		return r;
+	else if (!found)
+		return -ENOENT;
+
+	return 0;
+}
+
+int pidfds_to_pids(int *fds, pid_t *pids, int count)
+{
+	int fdinfo = -1;
+	int r = 0;
+	int i;
+
+	fdinfo = open_fdinfo_dir();
+	if (fdinfo == -1)
+		return -1;
+
+	for (i = 0; i < count && r == 0; i++)
+		r = pidfd_to_pid(fdinfo, fds[i], &pids[i]);
+
+	(void)close(fdinfo);
+
+	if (r != 0)
+		errno = -r;
+
+	return i;
+}
+
+/* misc directory helpers */
+int open_fdinfo_dir(void)
+{
+	int fd;
+
+	fd = open("/proc/self/fdinfo", O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
+
+	if (fd == -1)
+		return errno;
+
+	return fd;
+}

--- a/common/common-pidfds.h
+++ b/common/common-pidfds.h
@@ -1,0 +1,53 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+Copyright (c) 2019, Red Hat
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <sys/types.h>
+
+/* Open pidfds for up to count process ids specified in pids. The
+ * pointer fds needs to point to an array with at least count
+ * entries. Will stop when it encounters an error (and sets errno).
+ * Returns the number of successfully opened pidfds (or -1 in case
+ * of other errors. */
+int open_pidfds(pid_t *pids, int *fds, int count);
+
+/* Translate up to count process ids to the corresponding process ids.
+ * The pointer pids needs to point to an array with at least count
+ * entries. Will stop when it encounters an error (and sets errno).
+ * Returns the number of successfully translated pidfds (or -1 in
+ * case of other errors. */
+int pidfds_to_pids(int *fds, pid_t *pids, int count);
+
+/* Helper to open the fdinfo directory for the current process, i.e.
+ * does open("/proc/self/fdinfo", ...). Returns the file descriptor
+ * for the directory, ownership is transferred and caller needs to
+ * call close on it. */
+int open_fdinfo_dir(void);

--- a/common/meson.build
+++ b/common/meson.build
@@ -5,12 +5,14 @@ common_sources = [
     'common-external.c',
     'common-helpers.c',
     'common-gpu.c',
+    'common-pidfds.c',
 ]
 
 daemon_common = static_library(
     'daemon-common',
     sources: common_sources,
     install: false,
+    include_directories: [config_h_dir]
 )
 
 link_daemon_common = declare_dependency(

--- a/common/meson.build
+++ b/common/meson.build
@@ -15,6 +15,5 @@ daemon_common = static_library(
 
 link_daemon_common = declare_dependency(
     link_with: daemon_common,
+    include_directories: [include_directories('.')]
 )
-
-include_daemon_common = include_directories('.')

--- a/common/meson.build
+++ b/common/meson.build
@@ -19,3 +19,18 @@ link_daemon_common = declare_dependency(
     link_with: daemon_common,
     include_directories: [include_directories('.')]
 )
+
+lib_common = static_library(
+    'lib-common',
+    sources: [
+        'common-helpers.c',
+        'common-pidfds.c'
+    ],
+    install: false,
+    include_directories: [config_h_dir]
+)
+
+link_lib_common = declare_dependency(
+    link_with: lib_common,
+    include_directories: [include_directories('.')]
+)

--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -169,7 +169,7 @@ static int method_unregister_game_by_pid(sd_bus_message *m, void *userdata,
 }
 
 /**
- * Handles the QueryStatus D-BUS Method
+ * Handles the QueryStatusByPID D-BUS Method
  */
 static int method_query_status_by_pid(sd_bus_message *m, void *userdata,
                                       __attribute__((unused)) sd_bus_error *ret_error)
@@ -188,8 +188,9 @@ static int method_query_status_by_pid(sd_bus_message *m, void *userdata,
 
 	return sd_bus_reply_method_return(m, "i", status);
 }
+
 /**
- * Handles the Active D-BUS Method
+ * Handles the ClientCount D-BUS Property
  */
 static int property_get_client_count(sd_bus *local_bus, const char *path, const char *interface,
                                      const char *property, sd_bus_message *reply, void *userdata,

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -26,7 +26,6 @@ executable(
     ],
     include_directories: [
         gamemoded_includes,
-        include_daemon_common,
     ],
     install: true,
 )

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -76,12 +76,17 @@ static char error_string[512] = { 0 };
 // Helper to check if we are running inside a flatpak
 static int in_flatpak(void)
 {
-	struct stat sb;
-	int r;
+	static int status = -1;
 
-	r = lstat("/.flatpak-info", &sb);
+	if (status == -1) {
+		struct stat sb;
+		int r;
 
-	return r == 0 && sb.st_size > 0;
+		r = lstat("/.flatpak-info", &sb);
+		status = r == 0 && sb.st_size > 0;
+	}
+
+	return status;
 }
 
 static int log_error(const char *fmt, ...)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -12,6 +12,7 @@ gamemode = shared_library(
         'client_impl.c',
     ],
     dependencies: [
+        link_lib_common,
         dep_dbus,
     ],
     install: true,

--- a/meson.build
+++ b/meson.build
@@ -128,9 +128,13 @@ with_examples = get_option('with-examples')
 with_util = get_option('with-util')
 
 # Provide a config.h
+pidfd_open = cc.has_function('pidfd_open', args: '-D_GNU_SOURCE')
+
 cdata = configuration_data()
 cdata.set_quoted('LIBEXECDIR', path_libexecdir)
 cdata.set_quoted('GAMEMODE_VERSION', meson.project_version())
+cdata.set10('HAVE_FN_PIDFD_OPEN', pidfd_open)
+
 config_h = configure_file(
     configuration: cdata,
     output: 'build-config.h',

--- a/meson.build
+++ b/meson.build
@@ -141,11 +141,11 @@ config_h = configure_file(
 )
 config_h_dir = include_directories('.')
 
-# Library is always required
-subdir('lib')
-
 # common lib is always required
 subdir('common')
+
+# Library is always required
+subdir('lib')
 
 # Utilities are always required except when having both 64 and 32 bit versions
 # of libgamemode installed

--- a/util/meson.build
+++ b/util/meson.build
@@ -11,7 +11,6 @@ cpugovctl = executable(
         link_daemon_common,
     ],
     install: true,
-    include_directories: include_daemon_common,
     install_dir: path_libexecdir,
 )
 
@@ -27,6 +26,5 @@ gpuclockctl = executable(
         link_daemon_common,
     ],
     install: true,
-    include_directories: include_daemon_common,
     install_dir: path_libexecdir,
 )


### PR DESCRIPTION
Pidfds are process file descriptors representing processes. Since Linux [5.2](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit?id=b3e5838252665ee4cfa76b82bdf1198dca81e5be) the corresponding pid in the callers pid namespace can be obtained via the fdinfo in procfs; this by reading the "Pid:" field in '/proc/self/fdinfo/<pidfd>'. In Linux 5.3 the [`pidfd_open`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit?id=32fcb426ec001cb6d5a4a195091a8486ea77e2df) system call was added, allowing us to easily open a pidfd for a given pid. Additionally select/poll/epoll can be used to monitor the status of the process, which can be used to watch for process termination.
Add a new set of APIs, analogous to the existing *byPID APIs, that work with pidfds instead of pids and convert the client library to default to using those, if supported by the system. The two main advantages are:

  - pidfds drastically simplify the container use case, because there is no need to translate the pids between different namespaces anymore

  - it prepares the use of pidfds in the daemon, which in the future could be used to monitor process terminations and thus removes the need of the reaper background thread.