### PR TITLE
Add an option for using a different governor for integrated GPUs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -40,5 +40,10 @@ set -x
 
 sudo ninja install
 
+# Restart polkit so we don't get pop-ups whenever we pkexec
+if systemctl list-unit-files |grep -q polkit.service; then
+    sudo systemctl try-restart polkit
+fi
+
 # Reload systemd configuration so that it picks up the new service.
 systemctl --user daemon-reload

--- a/common/common-power.c
+++ b/common/common-power.c
@@ -1,0 +1,165 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+Copyright (c) 2019, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#define _GNU_SOURCE
+
+#include "common-power.h"
+#include "common-logging.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <glob.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <string.h>
+
+static bool read_file_in_dir(const char *dir, const char *file, char *dest, size_t n)
+{
+	char path[PATH_MAX];
+	int ret = snprintf(path, sizeof(path), "%s/%s", dir, file);
+	if (ret < 0 || ret >= (int)sizeof(path)) {
+		LOG_ERROR("Path length overrun");
+		return false;
+	}
+
+	FILE *f = fopen(path, "r");
+	if (!f) {
+		LOG_ERROR("Failed to open file for read %s\n", path);
+		return false;
+	}
+
+	size_t read = fread(dest, 1, n, f);
+
+	/* Close before we do any error checking */
+	fclose(f);
+
+	if (read <= 0) {
+		LOG_ERROR("Failed to read contents of %s: (%s)\n", path, strerror(errno));
+		return false;
+	}
+
+	if (read >= n) {
+		LOG_ERROR("File contained more data than expected %s\n", path);
+		return false;
+	}
+
+	/* Ensure we're null terminated */
+	dest[read] = '\0';
+
+	/* Trim whitespace off the end */
+	while (read > 0 && isspace(dest[read - 1])) {
+		dest[read - 1] = '\0';
+		read--;
+	}
+
+	return true;
+}
+
+static bool get_energy_uj(const char *rapl_name, uint32_t *energy_uj)
+{
+	glob_t glo = { 0 };
+	static const char *path = "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:*";
+
+	/* Assert some sanity on this glob */
+	if (glob(path, GLOB_NOSORT, NULL, &glo) != 0) {
+		LOG_ERROR("glob failed for RAPL paths: (%s)\n", strerror(errno));
+		return false;
+	}
+
+	/* If the glob doesn't find anything, this most likely means we don't
+	 * have an Intel CPU or we have a kernel which does not support RAPL on
+	 * our CPU.
+	 */
+	if (glo.gl_pathc < 1) {
+		LOG_ONCE(MSG,
+		         "Intel RAPL interface not found in sysfs. "
+		         "This is only problematic if you expected Intel iGPU "
+		         "power threshold optimization.");
+		globfree(&glo);
+		return false;
+	}
+
+	/* Walk the glob set */
+	for (size_t i = 0; i < glo.gl_pathc; i++) {
+		char name[32];
+		if (!read_file_in_dir(glo.gl_pathv[i], "name", name, sizeof(name))) {
+			return false;
+		}
+
+		/* We're searching for the directory where the file named "name"
+		 * contains the contents rapl_name. */
+		if (strncmp(name, rapl_name, sizeof(name)) != 0) {
+			continue;
+		}
+
+		char energy_uj_str[32];
+		if (!read_file_in_dir(glo.gl_pathv[i], "energy_uj", energy_uj_str, sizeof(energy_uj_str))) {
+			return false;
+		}
+
+		char *end = NULL;
+		long long energy_uj_ll = strtoll(energy_uj_str, &end, 10);
+		if (end == energy_uj_str) {
+			LOG_ERROR("Invalid energy_uj contents: %s\n", energy_uj_str);
+			return false;
+		}
+
+		if (energy_uj_ll < 0) {
+			LOG_ERROR("Value of energy_uj is out of expected bounds: %lld\n", energy_uj_ll);
+			return false;
+		}
+
+		/* Go ahead and clamp to 32 bits.  We assume 32 bits later when
+		 * taking deltas and wrapping at 32 bits is exactly what the Linux
+		 * kernel's turbostat utility does so it's probably right.
+		 */
+		*energy_uj = (uint32_t)energy_uj_ll;
+		return true;
+	}
+
+	/* If we got here then the CPU and Kernel support RAPL and all our file
+	 * access has succeeded but we failed to find an entry with the right
+	 * name.  This most likely means we're asking for "uncore" but are on a
+	 * machine that doesn't have an integrated GPU.
+	 */
+	return false;
+}
+
+bool get_cpu_energy_uj(uint32_t *energy_uj)
+{
+	return get_energy_uj("core", energy_uj);
+}
+
+bool get_igpu_energy_uj(uint32_t *energy_uj)
+{
+	return get_energy_uj("uncore", energy_uj);
+}

--- a/common/common-power.h
+++ b/common/common-power.h
@@ -1,0 +1,45 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * Get the amount of energy used to date by the CPU in microjoules
+ */
+bool get_cpu_energy_uj(uint32_t *energy_uj);
+
+/**
+ * Get the amount of energy used to date by the integrated GPU in microjoules
+ */
+bool get_igpu_energy_uj(uint32_t *energy_uj);

--- a/common/meson.build
+++ b/common/meson.build
@@ -6,6 +6,7 @@ common_sources = [
     'common-helpers.c',
     'common-gpu.c',
     'common-pidfds.c',
+    'common-power.c',
 ]
 
 daemon_common = static_library(

--- a/daemon/gamemode-config.h
+++ b/daemon/gamemode-config.h
@@ -102,6 +102,8 @@ bool config_get_inhibit_screensaver(GameModeConfig *self);
 long config_get_script_timeout(GameModeConfig *self);
 void config_get_default_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);
 void config_get_desired_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);
+void config_get_igpu_desired_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);
+float config_get_igpu_power_threshold(GameModeConfig *self);
 void config_get_soft_realtime(GameModeConfig *self, char softrealtime[CONFIG_VALUE_MAX]);
 long config_get_renice_value(GameModeConfig *self);
 long config_get_ioprio_value(GameModeConfig *self);

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -1,11 +1,20 @@
 [general]
-; The reaper thread will check every 5 seconds for exited clients and for config file changes
+; The reaper thread will check every 5 seconds for exited clients, for config file changes, and for the CPU/iGPU power balance
 reaper_freq=5
 
 ; The desired governor is used when entering GameMode instead of "performance"
 desiredgov=performance
 ; The default governer is used when leaving GameMode instead of restoring the original value
 defaultgov=powersave
+
+; The iGPU desired governor is used when the integrated GPU is under heavy load
+igpu_desiredgov=powersave
+; Threshold to use to decide when the integrated GPU is under heavy load.
+; This is a ratio of iGPU Watts / CPU Watts which is used to determine when the
+; integraged GPU is under heavy enough load to justify switching to
+; igpu_desiredgov.  Set this to -1 to disable all iGPU checking and always
+; use desiredgov for games.
+igpu_power_threshold=0.3
 
 ; GameMode can change the scheduler policy to SCHED_ISO on kernels which support it (currently
 ; not supported by upstream kernels). Can be set to "auto", "on" or "off". "auto" will enable


### PR DESCRIPTION
# Overview

This PR adds two new configuration options: igpu_desiredgov and igpu_power_threshold which allow for a different CPU governor when the Intel integrated GPU is under load.  This currently only applies to Intel integrated GPUs and not AMD APUs because it uses the Intel RAPL infrastructure for getting power information.  If on a platform that without an Intel integrated GPU or where the kernel does not support RAPL, the new options will be ignored and it will fall back to the old behavior.

One of the core principals of gamemode to date has been that, when playing a game, we want to use the "performance" CPU governor to increase CPU performance and prevent CPU-limiting.  However, when the integrated GPU is under load, this can be counter-productive because the CPU and GPU share a thermal and power budget.  By throwing the CPU governor to "performance" game mode currently makes the CPU frequency management far too aggressive and it burns more power than needed.  With a discrete GPU, this is fine because the worst that happens is a bit more fan noise.  With an integrated GPU, however, the additional power being burned by the CPU is power not available to the GPU and this can cause the GPU to clock down and lead to significantly worse performance.

By using the "powersave" governor instead of the "performance" governor while the integrated GPU is under load, we can save power on the CPU side which lets the GPU clock up higher.  On my Razer Blade Stealth 13 with an i7-1065G7, this improves the performance of "Shadow of the Tomb Raider" by around 25-30% according to its internal benchmark mode.

# Design

The design used in this PR makes some design trade-offs which may or may not be the right ones but I think it's enough to kick off the discussion.  The ideal design would probably be

    if (game_uses_integrated) {
        governor = "powersave";
    } else {
        governor = "performance";
    }

However, we don't actually know that information in the gamemode daemon.

The approach taken by this PR is to instead try to figure out if the integrated GPU is under a reasonably heavy load.  It does this by using the Intel RAPL framework to figure out how much power is being burned by the CPU and GPU.  The theory is that if the GPU is burning significant power relative to the CPU then we should use the powersave governor to try and give it more.

This approach has a number of problems:

 1. I assumed in this MR that the right threshold is if the GPU is burning more than 50% as much power as the CPU.  However, for a lighter-weight GPU that may be too low.  For a light-weight processor like an i3 or i5, it could end up being too high if the GPU is being used for compositing but you really want that little CPU to pull its weight.
 2. The algorithm is dynamic so it may be switching your governor back-and-forth.  If the threshold is set at the wrong spot, it could theoretically do this quite often and yield inconsistent performance.
 3. The algorithm is dynamic so if things aren't configured right, it can end up popping up a little authorization box every time it wants to switch governors rather than once when the game starts.  This gets annoying quickly.

It also has some significant upsides:

 1. Because it doesn't look at the static configuration of the system, it works even if you have a system with both a discrete GPU and an integrated GPU and it makes the right choice regardless of which you use without relying on changing your configuration.
 2. The algorithm is dynamic so it will throw your CPU into "performance" mode while sitting at a loading screen compiling shaders but then go into "powersave" within 5 seconds of getting into the game itself.

# Other design ideas

When looking into this, I considered a few other ideas which I think are worth enumerating.

 1. **Only apply the optimization if the game is using the integrated GPU.** This is the idea I mentioned above.  The problem is that the app doesn't pass that information to gamemode.  We could add it to the dbus protocol but there are already many games shipping with gamemode integration and they would never get the fix.  Even if we did try to do that, it'd be tricky to implement it in a consistent way because the vendor strings the app gets from something like GL might not translate well.
 1. **Only apply the optimization if the only GPU is integrated.**  This is one idea which @aejsmith and I threw around when discussing this problem a week ago or so.  There are two problems with it.  First is that it doesn't work on a hybrid setup so anyone who wants to play a game on their integrated card while they're on battery is toast.  The second is that it's actually rather annoying to figure out what your GPU topology looks like from a daemon.  It can be done but it's not as fun as one would like.
 1. **Look at what GPU devices the app opens.** We have the PID of the client which connected to gamemode so we could theoretically look at /proc and see what files it has open to try and figure out which GPU is in use.  However, this assumes that gamemode will be started by the process using the GPU rather than a wrapper, that the process is using the GPU before it talks to gamemode, and that the process only opens one GPU.
 2. **Look at GPU clock rates.**  This has the same problems as the power approach only it's a bit worse because the only APIs the kernel provides for querying those rates are instantaneous and so we'd have to poll them fairly often and look for patterns.  This, in and of itself, could get CPU intensive.
 3. **Look for some sort of GPU busy metric.**  Unfortunately, we don't have something like that easily exposed through any kernel interfaces at the moment.  Also, the obvious metrics we get from the hardware all require the OA unit which slows the whole GPU down when it's sampling.

I'm very much open to other design ideas.  I'm trying to enumerate as many as I can here to get the conversation going.  However, we need to come up with something because gamemode is actively hurting performance on integrated GPUs.  With distros shipping it and games enabling it in the hopes of better Linux perf, that's really bad for all the laptop users out there. :frowning: