### PR TITLE
prefer system installation of inih

### DIFF
--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -36,7 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "common-logging.h"
 
 /* Ben Hoyt's inih library */
-#include "ini.h"
+#include <ini.h>
 
 #include <dirent.h>
 #include <math.h>

--- a/meson.build
+++ b/meson.build
@@ -157,8 +157,10 @@ endif
 # main library
 if with_daemon == true
     # inih currently only needed by the daemon
-    inih = subproject('inih')
-    inih_dependency = inih.get_variable('inih_dependency')
+    inih_dependency = dependency(
+        'inih',
+        fallback : ['inih', 'inih_dependency']
+    )
 
     subdir('daemon')
 


### PR DESCRIPTION
With https://github.com/benhoyt/inih/pull/97 merged, it will be easy to install inih as a system library and declare the dependency with pkg-config. gamemode should use the system library instead of including the source, but we can still use it as a fallback ([see meson reference](https://mesonbuild.com/Subprojects.html#toggling-between-system-libraries-and-embedded-sources)).

Closes #195.
