### PR TITLE
use upstream inih r48

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "subprojects/inih"]
 	path = subprojects/inih
-	url = https://github.com/FeralInteractive/inih.git
+	url = https://github.com/benhoyt/inih.git

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ GameMode depends on `meson` for building and `systemd` for internal communicatio
 
 #### Ubuntu/Debian (you may also need `dbus-user-session`)
 ```bash
-apt install meson libsystemd-dev pkg-config ninja-build git libdbus-1-dev
+apt install meson libsystemd-dev pkg-config ninja-build git libdbus-1-dev libinih-dev
 ```
 #### Arch
 ```bash

--- a/meson.build
+++ b/meson.build
@@ -159,7 +159,7 @@ if with_daemon == true
     # inih currently only needed by the daemon
     inih_dependency = dependency(
         'inih',
-        fallback : ['inih', 'inih_dependency']
+        fallback : ['inih', 'inih_dep']
     )
 
     subdir('daemon')

--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -4,11 +4,7 @@ set -e
 # Simple script to construct a redistributable and complete tarball of the
 # gamemode tree, including the git submodules, so that it can be trivially
 # packaged by distributions banning networking during build.
-#
-# Modified from Ikey Doherty's release scripts for use within
-# Feral Interactive's gamemode project.
 git submodule init
-git submodule update
 
 # Bump in tandem with meson.build, run script once new tag is up.
 VERSION="1.6-dev"


### PR DESCRIPTION
I added meson support to inih, so we can use upstream inih.
Only drawback is that gamemode will now install `libinih.so.47` if it is in fallback mode (i.e. linking to the shared library and not against the static), but thanks to the meson build file in upstream inih it shouldn't be hard to pack inih for distro maintainers.
 It's probably a good idea to update the submodule to inih r48 once it is released and leave it there (should be fallback only anyway).