### PR TITLE
Use wrap instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subprojects/inih"]
-	path = subprojects/inih
-	url = https://github.com/benhoyt/inih.git

--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -2,9 +2,9 @@
 set -e
 
 # Simple script to construct a redistributable and complete tarball of the
-# gamemode tree, including the git submodules, so that it can be trivially
+# gamemode tree, including the subprojects, so that it can be trivially
 # packaged by distributions banning networking during build.
-git submodule init
+meson subprojects download
 
 # Bump in tandem with meson.build, run script once new tag is up.
 VERSION="1.6-dev"

--- a/subprojects/inih.wrap
+++ b/subprojects/inih.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/benhoyt/inih.git
+revision = r49


### PR DESCRIPTION
I noticed that it's easier to use wrap (native meson dependency tool) than git submodules, since:
1. It doesn't require a git repository to work, source tree is enough.
2. It's less hassle to change or update.
3. It is a detached git head, so less annoying in git viewers.
4. Would have prevented #202.
5. Maybe more meson compatibility (#204).