### PR TITLE
rename `example` to `gamemode-simulate-game`

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -1,6 +1,6 @@
 # An example game
 executable(
-    'example',
+    'gamemode-simulate-game',
     sources: [
         'main.c',
     ],


### PR DESCRIPTION
Naming the executable `example` isn't very descriptive - so I would rename it. We actually already did this in the Debian package for a long time since we ship the executable (it's a nice thing to test weather the setup works).