### PR TITLE
remove gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-build/
-builddir/
-*.swp


### PR DESCRIPTION
With meson gitignores are kinda useless, since the build files are de-coupled from the source code. Ignoring `build/` also is kinda sub-optimal since the meson project always uses `builddir` in their examples. Everyone can still use ignore stuff by using a local one .gitignore:
```gitignore
/.gitignore
/files/to/ignore
```