### PR TITLE
Add ATLauncher to gamemode support list and sort games alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following games are known to integrate GameMode support (meaning they don't 
 
 ### Others
 Other apps which can integrate with GameMode include:
+* [ATLauncher](https://atlauncher.com/downloads) Minecraft launcher
 * GNOME Shell ([via extension](https://github.com/gicmo/gamemode-extension)) - indicates when GameMode is active in the top panel.
 * Lutris - Enables GameMode for all games by default if available (must have both 32- and 64-bit GameMode libraries installed), configurable in preferences.
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ The following games are known to integrate GameMode support (meaning they don't 
 * DiRT 4
 * Rise of the Tomb Raider
 * Shadow of the Tomb Raider
+* Total War Saga: Thrones of Britannia
 * Total War: Three Kingdoms
 * Total War: WARHAMMER II
-* Total War Saga: Thrones of Britannia
 
 ### Others
 Other apps which can integrate with GameMode include:


### PR DESCRIPTION
ATLauncher has supported GameMode since version 3.3.2.0 so adding it to
the list of 'games' that support gamemode without any further
configuration.

https://github.com/ATLauncher/ATLauncher/releases/tag/3.3.2.0

Please note that the change with positioning for Total War Saga is because I sorted the list alphabetically in Vim. If you would rather this not be alphabetical I am happy to change it.