### PR TITLE
give gamemoderun an own man page

### DIFF
--- a/data/gamemoded.8.in
+++ b/data/gamemoded.8.in
@@ -1,8 +1,8 @@
 .\" Manpage for gamemoded.
 .\" Contact linux-contact@feralinteractive.com to correct errors or typos.
-.TH gamemoded 8 "3 Mar 2020" "1.6-dev" "gamemoded man page"
+.TH gamemoded 8 "4 May 2020" "1.6-dev" "gamemoded man page"
 .SH NAME
-gamemoded \- optimises system performance on demand
+gamemoded \- daemon that optimises system performance on demand
 .SH SYNOPSIS
 \fBgamemoded\fR [OPTIONS...]
 .SH DESCRIPTION
@@ -38,31 +38,7 @@ Run diagnostic tests on the current installation
 Print the version
 
 .SH USAGE
-\fBlibgamemodeauto.so.0\fR can be pre-loaded into any program to request \fBgamemoded\fR begin or end the mode, like so:
-
-.RS 4
-gamemoderun \./game
-.RE
-
-Or by setting the Steam launch options for a game:
-
-.RS 4
-gamemoderun %command%
-.RE
-
-The library can be manually preloaded if needed:
-
-.RS 4
-LD_PRELOAD=$LD_PRELOAD:/usr/\e$LIB/libgamemodeauto.so.0 ./game
-.RE
-
-It is possible to set additional start commands to gamemoderun by setting the environment variable:
-
-.RS 4
-GAMEMODERUNEXEC="command"
-.RE
-
-When this is set, gamemoderun will execute the command given by that environment variable, and the command line passed to gamemoderun will be passed as arguments to that command. GameMode will not be applied to the wrapper command, just the game itself.
+\fBlibgamemodeauto.so.0\fR can be pre-loaded into any program to request \fBgamemoded\fR begin or end the mode. See gamemoderun(1) for details.
 
 The \fBgamemode_client.h\fR header can be used by developers to build the requests into a program:
 
@@ -118,7 +94,7 @@ Behaviour of the config file can be explained by presenting a commented example:
 .RE
 
 .SH SEE ALSO
-systemd(1)
+gamemoderun(1), systemd(1)
 
 .SH ABOUT
 GameMode source can be found at \fIhttps://github.com/FeralInteractive/gamemode.git\fR

--- a/data/gamemoderun.1
+++ b/data/gamemoderun.1
@@ -1,0 +1,50 @@
+.\" Manpage for gamemoderun.
+.\" Contact linux-contact@feralinteractive.com to correct errors or typos.
+.TH gamemoded 1 "4 May 2020" "1.6-dev" "gamemoderun man page"
+.SH NAME
+gamemoderun \- invoke gamemode into any program
+.SH SYNOPSIS
+\fBgamemoderun\fR PROGRAM
+.SH DESCRIPTION
+\fBGameMode\fR is a daemon/lib combo for Linux that allows games to request a set of optimisations be temporarily applied to the host OS.
+
+The design has a clear cut abstraction between the host daemon and library (\fBgamemoded\fR and \fBlibgamemode\fR), and the client loaders (\fBlibgamemodeauto\fR and \fBgamemode_client.h\fR) that allows for safe usage without worrying about whether the daemon is installed or running. This design also means that while the host library currently relies on systemd for exchanging messages with the daemon, it's entirely possible to implement other internals that still work with the same clients.
+
+\fBGameMode\fR was designed primarily as a stop-gap solution to problems with the Intel and AMD CPU powersave or ondemand governors, but is intended to be expanded beyond just CPU governor states, as there are a wealth of automation tasks one might want to apply.
+
+.SH USAGE
+\fBlibgamemodeauto.so.0\fR can be pre-loaded into any program to request \fBgamemoded\fR begin or end the mode, like so:
+
+.RS 4
+gamemoderun \./game
+.RE
+
+Or by setting the Steam launch options for a game:
+
+.RS 4
+gamemoderun %command%
+.RE
+
+The library can be manually preloaded if needed:
+
+.RS 4
+LD_PRELOAD=$LD_PRELOAD:/usr/\e$LIB/libgamemodeauto.so.0 ./game
+.RE
+
+.SH CONFIG
+It is possible to set additional start commands to gamemoderun by setting the environment variable:
+
+.RS 4
+GAMEMODERUNEXEC="command"
+.RE
+
+When this is set, gamemoderun will execute the command given by that environment variable, and the command line passed to gamemoderun will be passed as arguments to that command. GameMode will not be applied to the wrapper command, just the game itself.
+
+.SH SEE ALSO
+gamemoded(8)
+
+.SH ABOUT
+GameMode source can be found at \fIhttps://github.com/FeralInteractive/gamemode.git\fR
+
+.SH AUTHOR
+Feral Interactive (linux-contact@feralinteractive.com)

--- a/data/meson.build
+++ b/data/meson.build
@@ -46,13 +46,24 @@ configure_file(
     install_mode: 'rwxr-xr-x',
 )
 
-# Configure and install the man page
-manpage = configure_file(
+# Configure and install man pages
+mandir = join_paths(prefix, get_option('mandir'))
+
+gamemoded_manpage = configure_file(
     input: files('gamemoded.8.in'),
     output: 'gamemoded.8',
     configuration: data_conf,
 )
-install_man(manpage)
+
+install_man(
+    gamemoded_manpage,
+    install_dir: mandir,
+)
+
+install_man(
+    files('gamemoderun.1'),
+    install_dir: mandir,
+)
 
 # Install metainfo
 install_data(


### PR DESCRIPTION
Every binary should have a man page describing what the program does, whether there are options or not - in Debian, a missing man page is even considered a bug.

Since the gamemoded man page already contained a lot of information about gamemoderun, I just copied it to a new one.