### PR TITLE
Generate version via git instead of using -dev

### DIFF
--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -7,10 +7,9 @@ set -e
 meson subprojects download
 meson subprojects update
 
-# Bump in tandem with meson.build, run script once new tag is up.
-VERSION="1.6-dev"
-
 NAME="gamemode"
+VERSION=$(git describe --tags --dirty)
+
 ./scripts/git-archive-all.sh --format tar --prefix ${NAME}-${VERSION}/ --verbose -t HEAD ${NAME}-${VERSION}.tar
 xz -9 "${NAME}-${VERSION}.tar"
 


### PR DESCRIPTION
This is an attempt to remove the -dev commits after releases.
This does work quite nicely with distros too, since they either build unmodified from git anyway (e. g. Arch Linux), or from the source tarball, where no .git folder is given (e. g. Debian).

One thing I'm unsure is the `--dirty` option, this adds `-dirty` if there are non-committed changes in the workdir, it can be a nice reminder but also potentially break if your default build dir is not in a gitignore (see #217), so I would like to hear some opinions here.