### PR TITLE
Meson: use builddir instead of build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
+builddir/
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ addons:
 script:
   - ./scripts/format-check.sh
   - ./bootstrap.sh -Dwith-examples=true
-  - meson test -C build
+  - meson test -C builddir
   - dbus-run-session -- gamemode-simulate-game
   - ./scripts/static-analyser-check.sh 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ git checkout 1.5.1 # omit to build the master branch
 To uninstall:
 ```bash
 systemctl --user stop gamemoded.service
-cd build/
-ninja uninstall
+ninja uninstall -C builddir
 ```
 
 ### Pull Requests

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,9 +26,8 @@ fi
 
 # Echo the rest so it's obvious
 set -x
-meson --prefix=$prefix build --buildtype debugoptimized -Dwith-systemd-user-unit-dir=/etc/systemd/user "$@"
-cd build
-ninja
+meson builddir --prefix=$prefix --buildtype debugoptimized -Dwith-systemd-user-unit-dir=/etc/systemd/user "$@"
+ninja -C builddir
 
 # Verify user wants to install
 set +x
@@ -38,7 +37,7 @@ if [ "$TRAVIS" != "true" ]; then
 fi
 set -x
 
-sudo ninja install
+sudo ninja install -C builddir
 
 # Restart polkit so we don't get pop-ups whenever we pkexec
 if systemctl list-unit-files |grep -q polkit.service; then

--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -5,6 +5,7 @@ set -e
 # gamemode tree, including the subprojects, so that it can be trivially
 # packaged by distributions banning networking during build.
 meson subprojects download
+meson subprojects update
 
 # Bump in tandem with meson.build, run script once new tag is up.
 VERSION="1.6-dev"

--- a/scripts/static-analyser-check.sh
+++ b/scripts/static-analyser-check.sh
@@ -3,11 +3,8 @@
 # Exit on failure
 set -e
 
-# Build directly
-cd build/
-
 # Collect scan-build output
-ninja scan-build | tee /tmp/scan-build-results.txt
+ninja scan-build -C builddir | tee /tmp/scan-build-results.txt
 
 # Invert the output - if this string exists it's a fail
 ! grep -E '[0-9]+ bugs? found.' /tmp/scan-build-results.txt


### PR DESCRIPTION
See also #217. Since there doesn't seem to be a consensus to remove the gitignore, I would like to switch at least to `builddir` instead of `build` as it is recommended by Meson (https://github.com/mesonbuild/meson/commit/f3be687cbbfd1ff25c7ec4ffe8ba4adfee9a6579).

I also sneaked in a potential fix in `mkrelease.sh`, it could happen that the one creating the release tarball has an old version of inih, in this case meson doesn't re-download it when running `meson subprojects download`, to do this `meson subprojects update` needs to be run.