### PR TITLE
Meson: explicitly set include path

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -43,7 +43,10 @@ gamemode_headers = [
     'gamemode_client.h',
 ]
 
-install_headers(gamemode_headers)
+install_headers(
+    gamemode_headers,
+    install_dir: path_includedir,
+)
 
 # Generate a pkg-config files
 pkg = import('pkgconfig')


### PR DESCRIPTION
Not that it would change anything in the real world, but it's good practice. Somewhat related if anyone wants to read up on the topic: https://wiki.debian.org/Multiarch/TheCaseForMultiarch#Proposed_general_solution, https://wiki.ubuntu.com/MultiarchSpec#Co-installable_-dev_packages