### PR TITLE
Meson updates for the libraries

### DIFF
--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -11,7 +11,7 @@ daemon_sources = [
     'gamemode-config.c',
 ]
 
-gamemoded_includes = libgamemode_includes
+gamemoded_includes = gamemode_headers_includes
 gamemoded_includes += config_h_dir
 
 gamemoded = executable(

--- a/example/meson.build
+++ b/example/meson.build
@@ -5,8 +5,7 @@ executable(
         'main.c',
     ],
     dependencies: [
-        libgamemode_dep,
-        libdl,
+        gamemode_dep,
     ],
     install: true,
     install_dir: path_bindir,

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -6,7 +6,7 @@ lt_age = '0'
 lt_version = '@0@.@1@.@2@'.format(lt_current, lt_age, lt_revision)
 
 # Main client library to message the daemon
-gamemode = shared_library(
+libgamemode = shared_library(
     'gamemode',
     sources: [
         'client_impl.c',
@@ -20,12 +20,12 @@ gamemode = shared_library(
     version: lt_version,
 )
 
-libgamemode_includes = [
+gamemode_headers_includes = [
     include_directories('.'),
 ]
 
 # Small library to automatically use gamemode
-gamemodeauto = both_libraries(
+libgamemodeauto = both_libraries(
     'gamemodeauto',
     sources: [
         'client_loader.c',
@@ -72,10 +72,11 @@ pkg.generate(
   ],
 )
 
-# Dependency objects for the libs
-libgamemode_dep = declare_dependency(
-  include_directories: libgamemode_includes,
+# Dependency objects
+gamemode_dep = declare_dependency(
+  include_directories: gamemode_headers_includes,
+  dependencies: libdl,
 )
 libgamemodeauto_dep = declare_dependency(
-  link_with: gamemodeauto,
+  link_with: libgamemodeauto,
 )

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -62,14 +62,11 @@ pkg.generate(
 )
 
 pkg.generate(
-  name: 'gamemode',
+  name: 'libgamemodeauto',
   description: desc,
-  filebase: 'gamemode-auto',
-  libraries: gamemodeauto,
+  filebase: 'libgamemodeauto',
+  libraries: libgamemodeauto,
   version: meson.project_version(),
-  libraries_private: [
-    libdl
-  ],
 )
 
 # Dependency objects

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -25,7 +25,7 @@ libgamemode_includes = [
 ]
 
 # Small library to automatically use gamemode
-gamemodeauto = shared_library(
+gamemodeauto = both_libraries(
     'gamemodeauto',
     sources: [
         'client_loader.c',


### PR DESCRIPTION
This does a couple of things:
- `libgamemodeauto` is now also build statically, which I think is an important use case in game development.
- Various updates for misleading variable names.
- A small, but very drastic change, the pkg-config entry for libgamemodeauto is renamed. This might be a _breaking_ change for developers who actually used that entry (which I highly doubt exist btw). I think before it wasn't entirely clear how the pkg-config entries differ. I hope that this makes clear that linking against libgamemodeauto is indeed very different from using the gamemode pkg-config entry.
