### PR TITLE
Update README instructions to point to release 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ ACCEPT_KEYWORDS="**" emerge --ask ~games-util/gamemode-9999
 ```
 
 ### Build and Install GameMode
-Then clone, build and install a release version of GameMode at 1.5.1:
+Then clone, build and install a release version of GameMode at 1.6:
 
 ```bash
 git clone https://github.com/FeralInteractive/gamemode.git
 cd gamemode
-git checkout 1.5.1 # omit to build the master branch
+git checkout 1.6 # omit to build the master branch
 ./bootstrap.sh
 ```
 


### PR DESCRIPTION
Hi! Since the release 1.6 has been out for 7 days I figure maybe it's time to update the README.md install guide? 

This PR bumps the version to 1.6 in the README steps. If you want people to start using this version of course. 👋🏼 