### PR TITLE
Add libinih pacman dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ apt install meson libsystemd-dev pkg-config ninja-build git libdbus-1-dev libini
 ```
 #### Arch
 ```bash
-pacman -S meson systemd git dbus
+pacman -S meson systemd git dbus libinih
 ```
 #### Fedora
 ```bash


### PR DESCRIPTION
Libinih has been added to the [community] repository.
https://www.archlinux.org/packages/community/x86_64/libinih/

Also gamemode.
https://www.archlinux.org/packages/community/x86_64/gamemode/