### PR TITLE
Run executables from PATH instead of /usr/bin

### DIFF
--- a/common/common-external.c
+++ b/common/common-external.c
@@ -140,7 +140,7 @@ int run_external_process(const char *const *exec_args, char buffer[EXTERNAL_BUFF
 		 *   bindings that these objects are completely constant.
 		 * http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
 		 */
-		if (execv(exec_args[0], (char *const *)exec_args) != 0) {
+		if (execvp(exec_args[0], (char *const *)exec_args) != 0) {
 			LOG_ERROR("Failed to execute external process: %s %s\n", exec_args[0], strerror(errno));
 			exit(EXIT_FAILURE);
 		}

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -235,7 +235,7 @@ static int game_mode_set_governor(GameModeContext *self, enum GameModeGovernor g
 	}
 
 	const char *const exec_args[] = {
-		"/usr/bin/pkexec", LIBEXECDIR "/cpugovctl", "set", gov_str, NULL,
+		"pkexec", LIBEXECDIR "/cpugovctl", "set", gov_str, NULL,
 	};
 
 	LOG_MSG("Requesting update of governor policy to %s\n", gov_str);

--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -167,7 +167,7 @@ int game_mode_apply_gpu(const GameModeGPUInfo *info)
 
 	// Set up our command line to pass to gpuclockctl
 	const char *const exec_args[] = {
-		"/usr/bin/pkexec",
+		"pkexec",
 		LIBEXECDIR "/gpuclockctl",
 		device,
 		"set",

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -268,7 +268,7 @@ static int run_gamemoderun_and_reaper_tests(struct GameModeConfig *config)
 		/* Close stdout, we don't care if sh prints anything */
 		fclose(stdout);
 		/* Preload into sh and then kill it */
-		if (execl("/usr/bin/gamemoderun", "/usr/bin/gamemoderun", "sleep", "5", (char *)NULL) ==
+		if (execlp("gamemoderun", "gamemoderun", "sleep", "5", (char *)NULL) ==
 		    -1) {
 			LOG_ERROR("failed to launch gamemoderun with execl: %s\n", strerror(errno));
 			return -1;

--- a/util/gpuclockctl.c
+++ b/util/gpuclockctl.c
@@ -70,7 +70,7 @@ static void print_usage_and_exit(void)
 static const char *get_nv_attr(const char *attr)
 {
 	static char out[EXTERNAL_BUFFER_MAX];
-	const char *exec_args[] = { "/usr/bin/nvidia-settings", "-q", attr, "-t", NULL };
+	const char *exec_args[] = { "nvidia-settings", "-q", attr, "-t", NULL };
 	if (run_external_process(exec_args, out, -1) != 0) {
 		LOG_ERROR("Failed to get %s!\n", attr);
 		out[0] = 0;
@@ -82,7 +82,7 @@ static const char *get_nv_attr(const char *attr)
 
 static int set_nv_attr(const char *attr)
 {
-	const char *exec_args_core[] = { "/usr/bin/nvidia-settings", "-a", attr, NULL };
+	const char *exec_args_core[] = { "nvidia-settings", "-a", attr, NULL };
 	if (run_external_process(exec_args_core, NULL, -1) != 0) {
 		LOG_ERROR("Failed to set %s!\n", attr);
 		return -1;


### PR DESCRIPTION
Not all distributions install non-system binaries into /usr/bin. For
example, NixOS installs packages to /nix/store using a unique hash
generated from the inputs used to build it:

/nix/store/jld7jh3ilvbg91zvn1bdyawfc55b9jk8-polkit-0.118-bin/bin/pkexec