### PR TITLE
Fix loading shipped config when using a prefix other than /usr

### DIFF
--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -35,6 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "common-helpers.h"
 #include "common-logging.h"
 
+#include "build-config.h"
+
 /* Ben Hoyt's inih library */
 #include <ini.h>
 
@@ -277,9 +279,7 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			    "The [gpu] config section is not configurable from unsafe config files! Option %s "
 			    "will be ignored!\n",
 			    name);
-			LOG_ERROR(
-			    "Consider moving this option to /etc/gamemode.ini or "
-			    "/usr/share/gamemode/gamemode.ini\n");
+			LOG_ERROR("Consider moving this option to /etc/gamemode.ini\n");
 		}
 
 		/* GPU subsection */
@@ -378,7 +378,7 @@ static void load_config_files(GameModeConfig *self)
 		bool protected;
 	};
 	struct ConfigLocation locations[CONFIG_NUM_LOCATIONS] = {
-		{ "/usr/share/gamemode", true }, /* shipped default config */
+		{ SYSCONFDIR, true },            /* shipped default config */
 		{ "/etc", true },                /* administrator config */
 		{ config_location_home, false }, /* $XDG_CONFIG_HOME or $HOME/.config/ */
 		{ config_location_local, false } /* local data eg. $PWD */

--- a/data/gamemoded.8.in
+++ b/data/gamemoded.8.in
@@ -73,7 +73,7 @@ Or, distribute \fBlibgamemodeauto.so.0\fR and either link with \fB\-lgamemodeaut
 \fBgamemoded\fR will load and merge \fBgamemode.ini\fR config files from these directories in the following order:
 
 .RS 4
-/usr/share/gamemode/
+@SYSCONFDIR@/
 .RE
 .RS 4
 /etc/

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,7 @@
 data_conf = configuration_data()
 data_conf.set('BINDIR', path_bindir)
 data_conf.set('LIBEXECDIR', path_libexecdir)
+data_conf.set('SYSCONFDIR', path_sysconfdir)
 data_conf.set('GAMEMODE_PREFIX', path_prefix)
 data_conf.set('GAMEMODE_VERSION', meson.project_version())
 

--- a/meson.build
+++ b/meson.build
@@ -142,6 +142,7 @@ pidfd_open = cc.has_function('pidfd_open', args: '-D_GNU_SOURCE')
 
 cdata = configuration_data()
 cdata.set_quoted('LIBEXECDIR', path_libexecdir)
+cdata.set_quoted('SYSCONFDIR', path_sysconfdir)
 cdata.set_quoted('GAMEMODE_VERSION', meson.project_version())
 cdata.set10('HAVE_FN_PIDFD_OPEN', pidfd_open)
 


### PR DESCRIPTION
Also remove recommendation to modify `/usr/share/gamemode/gamemode.ini`.
`/usr/share` is intended to contain read-only data files.

See https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html.