### PR TITLE
New utility: gamemodelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,26 @@ See repository subdirectories for information on each component.
 GameMode depends on `meson` for building and `systemd` for internal communication. This repo contains a `bootstrap.sh` script to allow for quick install to the user bus, but check `meson_options.txt` for custom settings.
 
 #### Ubuntu/Debian (you may also need `dbus-user-session`)
+
 ```bash
 apt install meson libsystemd-dev pkg-config ninja-build git libdbus-1-dev libinih-dev build-essential
 ```
+
+On Ubuntu 18.04, you'll need to install `python3` package and install the latest meson version from `pip`.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install meson
+```
+
+Later you can deactivate the virtual environment and remove it.
+
+```bash
+deactivate
+rm -rf .venv
+```
+
 #### Arch
 ```bash
 pacman -S meson systemd git dbus libinih

--- a/data/gamemodelist
+++ b/data/gamemodelist
@@ -4,7 +4,9 @@
 # MIT License - https://github.com/samrocketman/home
 
 # DESCRIPTION
-#     Find all running processes which have Feral Interactive gamemode enabled.
+#     Find all running processes which have loaded Feral Interactive gamemode
+#     via libgamemodeauto.so.  This script will not detect processes which load
+#     gamemode without libgamemodeauto.so.
 
 # DEVELOPMENT ENVIRONMENT
 #     Ubuntu 18.04.6 LTS

--- a/data/gamemodelist
+++ b/data/gamemodelist
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Created by Sam Gleske
+# Created Sat Jan  1 16:56:54 EST 2022
+# MIT License - https://github.com/samrocketman/home
+
+# DESCRIPTION
+#     Find all running processes which have Feral Interactive gamemode enabled.
+
+# DEVELOPMENT ENVIRONMENT
+#     Ubuntu 18.04.6 LTS
+#     Linux 5.4.0-91-generic x86_64
+#     GNU bash, version 4.4.20(1)-release (x86_64-pc-linux-gnu)
+#     find (GNU findutils) 4.7.0-git
+#     GNU Awk 4.1.4, API: 1.1 (GNU MPFR 4.0.1, GNU MP 6.1.2)
+#     xargs (GNU findutils) 4.7.0-git
+#     ps from procps-ng 3.3.12
+
+if [ -z "${USER:-}" ]; then
+  echo '$USER variable not defined.' >&2
+  exit 1
+fi
+
+if [ ! -d /proc ]; then
+  echo 'ERROR: /proc filesystem missing.  We do not appear to be running on Linux.' >&2
+  exit 1
+fi
+
+find /proc -maxdepth 2 -type f -user "${USER}" -readable -name maps -exec \
+  awk -- '$0 ~ /libgamemodeauto\.so\.0/ {pid=FILENAME; gsub("[^0-9]", "", pid); print pid;nextfile}' {} + \
+  | xargs | xargs -I{} -- ps -o pid,ppid,user,ni,psr,comm --pid '{}'

--- a/data/gamemodelist.1.in
+++ b/data/gamemodelist.1.in
@@ -1,0 +1,68 @@
+.\" Manpage for gamemoderun.
+.\" Contact linux-contact@feralinteractive.com to correct errors or typos.
+.TH gamemodelist 1 "4 May 2020" "@GAMEMODE_VERSION@" "gamemodelist man page"
+.SH NAME
+gamemodelist \- search for processes running with gamemode
+.SH SYNOPSIS
+\fBgamemodelist\fR
+.SH DESCRIPTION
+\fBgamemodelist\fR will search the runtime of all processes running with \fBGameMode\fR enabled and print them with
+.BR ps (1)
+command output.  This helper script makes it easy to find which processes are utilizing \fBGameMode\fR when troubleshooting potential game issues.
+
+.SH USAGE
+\fBlibgamemodeauto.so.0\fR will be found in the shared object maps of running processes utilizing \fBGameMode\fR.  Run the following command to print processes loaded with \fBlibgamemodeauto.so.0\fR.
+
+.RS 4
+gamemodelist
+.RE
+
+.SH OUTPUT
+The output is a process table from
+.BR ps (1)
+command.
+
+.RS 4
+PID PPID USER NI PSR COMMAND
+.RE
+
+Where each of these fields are defined in
+.BR ps (1)
+manual.  For your convenience here's a definition for each field.
+
+.RS 4
+.TS
+l lw(3i).
+\fBCOLUMN	DESCRIPTION\fR
+PID	Process ID
+PPID	Parent process ID
+USER	User name owning the process.
+NI	T{
+Nice value. This ranges from 19 (nicest) to \-20 (not nice to others),
+See
+.IR nice (1).
+T}
+PSR	T{
+Processor that process is currently assigned to.  Useful when setting process affinity using
+.IR taskset (1)
+utility.
+T}
+COMMAND	Command name (only the executable name).
+.TE
+.RE
+
+.SH SEE ALSO
+.BR gamemodrun (1),
+.BR nice (1),
+.BR ps (1),
+.BR taskset (1).
+
+.SH ABOUT
+GameMode source can be found at \fIhttps://github.com/FeralInteractive/gamemode.git\fR
+
+.SH AUTHOR
+.BR gamemodelist
+was authored by Sam Gleske (https://github.com/samrocketman/)
+
+.BR GameMode
+was authored by Feral Interactive (linux-contact@feralinteractive.com)

--- a/data/gamemodelist.1.in
+++ b/data/gamemodelist.1.in
@@ -6,12 +6,12 @@ gamemodelist \- search for processes running with gamemode
 .SH SYNOPSIS
 \fBgamemodelist\fR
 .SH DESCRIPTION
-\fBgamemodelist\fR will search the runtime of all processes running with \fBGameMode\fR enabled and print them with
+\fBgamemodelist\fR will search the runtime of all processes running which started \fBGameMode\fR via \fBlibgamemodeauto.so\fR and print them with
 .BR ps (1)
-command output.  This helper script makes it easy to find which processes are utilizing \fBGameMode\fR when troubleshooting potential game issues.
+command output.  This helper script makes it easy to find which processes are utilizing \fBGameMode\fR via \fBlibgamemodeauto.so\fR when troubleshooting potential game issues.
 
 .SH USAGE
-\fBlibgamemodeauto.so.0\fR will be found in the shared object maps of running processes utilizing \fBGameMode\fR.  Run the following command to print processes loaded with \fBlibgamemodeauto.so.0\fR.
+\fBlibgamemodeauto.so.0\fR will be found in the shared object maps of running processes utilizing \fBGameMode\fR.  Run the following command to print processes loaded with \fBlibgamemodeauto.so.0\fR.  \fBGameMode\fR can be started other ways but this script will only detect processes utilizing \fBGameMode\fR via \fBlibgamemodeauto.so\fR.
 
 .RS 4
 gamemodelist

--- a/data/meson.build
+++ b/data/meson.build
@@ -51,6 +51,13 @@ install_data(
     install_mode: 'rwxr-xr-x',
 )
 
+# Install script to find processes with gamemode lib in runtime
+install_data(
+    files('gamemodelist'),
+    install_dir: path_bindir,
+    install_mode: 'rwxr-xr-x',
+)
+
 # Configure and install man pages
 gamemoded_manpage = configure_file(
     input: files('gamemoded.8.in'),
@@ -71,6 +78,17 @@ gamemoderun_manpage = configure_file(
 
 install_man(
     gamemoderun_manpage,
+    install_dir: join_paths(path_mandir, 'man1')
+)
+
+gamemodelist_manpage = configure_file(
+    input: files('gamemodelist.1.in'),
+    output: 'gamemodelist.1',
+    configuration: data_conf,
+)
+
+install_man(
+    gamemodelist_manpage,
     install_dir: join_paths(path_mandir, 'man1')
 )
 


### PR DESCRIPTION
While trying out gamemode on Ubuntu 18.04 I had trouble figuring out whether or not my games were running with gamemode enabled.  I wrote this utility which prints all processes loaded with the gamemode shared library.

- [x] Added utility to `data/` folder.
- [x] Update meson installer.
- [x] Included section 1 manual.
- [x] Updated README for Ubuntu 18.04 build instructions.  Steam supports Ubuntu 18.04.

I'm open to feedback and generally this should work for any distribution since it makes use of the Linux `/proc` filesystem.  [Learn more about `/proc`][1].

### Thanks in advance

![image](https://user-images.githubusercontent.com/875669/147866140-e8e6c55e-4e3c-49f9-846e-c8ade68b7e32.png)

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/filesystems/proc.rst?h=v5.15.12