### PR TITLE
Fix GitHub Actions Format Check

### DIFF
--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -268,8 +268,7 @@ static int run_gamemoderun_and_reaper_tests(struct GameModeConfig *config)
 		/* Close stdout, we don't care if sh prints anything */
 		fclose(stdout);
 		/* Preload into sh and then kill it */
-		if (execlp("gamemoderun", "gamemoderun", "sleep", "5", (char *)NULL) ==
-		    -1) {
+		if (execlp("gamemoderun", "gamemoderun", "sleep", "5", (char *)NULL) == -1) {
 			LOG_ERROR("failed to launch gamemoderun with execl: %s\n", strerror(errno));
 			return -1;
 		}


### PR DESCRIPTION
This change fixes the format check in GitHub actions ran by `clang-format`.

<details><summary><b>Hidden environment setup (click to expand)</b></summary>

---

# Dockerfile

```dockerfile
FROM ubuntu:20.04

ENV DEBIAN_FRONTEND=noninteractive

RUN set -ex; \
apt-get update; \
apt-get install -y build-essential meson appstream clang clang-format clang-tools libdbus-1-dev libinih-dev libsystemd-dev git

RUN set -ex; \
yes | adduser ci-user

USER ci-user
```

# Environment setup

```bash
sudo su -g docker $USER
docker build -t ci .
```

</details>

---

# clang-format fix

```bash
docker run -e CI=true --rm -v "$PWD:$PWD" -w "$PWD" --init ci ./scripts/format-check.sh
```

# Old Puppy

![image](https://user-images.githubusercontent.com/875669/154828654-d6054c2b-c636-4537-bdcd-2c5d831f711c.png)