### PR TITLE
Added instruction to Readme: Test if GameMode installed/running correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ cd gamemode
 git checkout 1.6.1 # omit to build the master branch
 ./bootstrap.sh
 ```
-To test it installed correctly:
+To test GameMode installed and will run correctly:
 ```bash
 gamemoded -t
 ```

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ cd gamemode
 git checkout 1.6.1 # omit to build the master branch
 ./bootstrap.sh
 ```
+To test it installed correctly:
+```bash
+gamemoded -t
+```
 
 To uninstall:
 ```bash


### PR DESCRIPTION
Added the terminal command 'gamemode -t' to the Readme file in the Install section to help people verify if GameMode has installed and will run correctly. 

Suggesting this edit after some discussion on /r/linux_gaming where a lot of people didn't know this command existed (it is listed in the --help section, but may be missed). 