### PR TITLE
Fix build on musl libc

### DIFF
--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -45,6 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <assert.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <sys/time.h>


### PR DESCRIPTION
This simple patch includes signal.h in daemon/gamemode-context.c to fix building gamemode on musl
libc.

This has been tested Gentoo musl and Alpine (also Gentoo glibc to
ensure no multiple defined symbols/other errors for glibc).

> ../daemon/gamemode-context.c: In function 'game_mode_context_auto_expire':
> ../daemon/gamemode-context.c:421:29: error: implicit declaration of function 'kill' [-Werror=implicit-function-declaration]
>   421 |                         if (kill(client->pid, 0) != 0) {
>       |                             ^~~~
> ../daemon/gamemode-context.c:421:29: warning: nested extern declaration of 'kill' [-Wnested-externs]

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>