### PR TITLE
meson: fix warning in run_command

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -8,7 +8,8 @@ data_conf.set('GAMEMODE_VERSION', meson.project_version())
 # Pull in the example config
 config_example = run_command(
     'cat',
-    join_paths(meson.source_root(), 'example', 'gamemode.ini')
+    join_paths(meson.source_root(), 'example', 'gamemode.ini'),
+    check: true,
 ).stdout().strip()
 data_conf.set('GAMEMODE_EXAMPLE_CONFIG', config_example)
 


### PR DESCRIPTION
Fixes this warning:
```
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
```
