### PR TITLE
Don't force installation of static libgamemodeauto

### DIFF
--- a/data/gamemodelist.1.in
+++ b/data/gamemodelist.1.in
@@ -1,4 +1,4 @@
-.\" Manpage for gamemoderun.
+.\" Manpage for gamemodelist.
 .\" Contact linux-contact@feralinteractive.com to correct errors or typos.
 .TH gamemodelist 1 "4 May 2020" "@GAMEMODE_VERSION@" "gamemodelist man page"
 .SH NAME

--- a/data/meson.build
+++ b/data/meson.build
@@ -70,12 +70,27 @@ if with_privileged_group != ''
     )
 endif
 
-# Install the helper run script
-install_data(
-    files('gamemoderun'),
-    install_dir: path_bindir,
-    install_mode: 'rwxr-xr-x',
-)
+# Install the helper run script and man page
+if get_option('default_library') == 'static'
+    warning('gamemoderun will not be installed as a shared libgamemodeauto library is required')
+else
+    install_data(
+        files('gamemoderun'),
+        install_dir: path_bindir,
+        install_mode: 'rwxr-xr-x',
+    )
+
+    gamemoderun_manpage = configure_file(
+        input: files('gamemoderun.1.in'),
+        output: 'gamemoderun.1',
+        configuration: data_conf,
+    )
+
+    install_man(
+        gamemoderun_manpage,
+        install_dir: join_paths(path_mandir, 'man1')
+    )
+endif
 
 # Install script to find processes with gamemode lib in runtime
 install_data(
@@ -94,17 +109,6 @@ gamemoded_manpage = configure_file(
 install_man(
     gamemoded_manpage,
     install_dir: join_paths(path_mandir, 'man8')
-)
-
-gamemoderun_manpage = configure_file(
-    input: files('gamemoderun.1.in'),
-    output: 'gamemoderun.1',
-    configuration: data_conf,
-)
-
-install_man(
-    gamemoderun_manpage,
-    install_dir: join_paths(path_mandir, 'man1')
 )
 
 gamemodelist_manpage = configure_file(

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -25,7 +25,7 @@ gamemode_headers_includes = [
 ]
 
 # Small library to automatically use gamemode
-libgamemodeauto = both_libraries(
+libgamemodeauto = library(
     'gamemodeauto',
     sources: [
         'client_loader.c',


### PR DESCRIPTION
Defining the library with `library` rather than `both_libraries` allows the user to choose which type they want to install using `-Ddefault_library`.

Closes: https://github.com/FeralInteractive/gamemode/issues/287