### PR TITLE
Fix building when pidfd_open is available

### DIFF
--- a/common/common-pidfds.c
+++ b/common/common-pidfds.c
@@ -58,6 +58,8 @@ static int pidfd_open(pid_t pid, unsigned int flags)
 {
 	return (int)syscall(__NR_pidfd_open, pid, flags);
 }
+#else
+#include <sys/pidfd.h>
 #endif
 
 /* pidfd functions */


### PR DESCRIPTION
On glibc 2.36 pidfd_open was made available, but doesn't work without an include.

Should fix: #377 