### PR TITLE
Fix build with glibc 2.36

### DIFF
--- a/common/common-pidfds.c
+++ b/common/common-pidfds.c
@@ -47,7 +47,11 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/types.h>
 #include <unistd.h>
 
-#if !HAVE_FN_PIDFD_OPEN
+#if HAVE_FN_PIDFD_OPEN
+#if HAVE_SYS_PIDFD_H
+#include <sys/pidfd.h>
+#endif
+#else
 #include <sys/syscall.h>
 
 #ifndef __NR_pidfd_open

--- a/meson.build
+++ b/meson.build
@@ -154,12 +154,14 @@ with_util = get_option('with-util')
 
 # Provide a config.h
 pidfd_open = cc.has_function('pidfd_open', args: '-D_GNU_SOURCE')
+sys_pidfd_h = cc.has_header('sys/pidfd.h')
 
 cdata = configuration_data()
 cdata.set_quoted('LIBEXECDIR', path_libexecdir)
 cdata.set_quoted('SYSCONFDIR', path_sysconfdir)
 cdata.set_quoted('GAMEMODE_VERSION', meson.project_version())
 cdata.set10('HAVE_FN_PIDFD_OPEN', pidfd_open)
+cdata.set10('HAVE_SYS_PIDFD_H', sys_pidfd_h)
 
 config_h = configure_file(
     configuration: cdata,


### PR DESCRIPTION
glibc 2.36 has added the pidfd_open function, if sys/pidfd.h exists then
we should include it.

Fixes the following error:

    ../common/common-pidfds.c: In function ‘open_pidfds’:
    ../common/common-pidfds.c:70:26: error: implicit declaration of function ‘pidfd_open’; did you mean ‘fdopen’? [-Werror=implicit-function-declaration]
       70 |                 int fd = pidfd_open(pid, 0);
          |                          ^~~~~~~~~~
          |                          fdopen