### PR TITLE
Set the default GPU device ID to 0

### DIFF
--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -363,7 +363,7 @@ static void load_config_files(GameModeConfig *self)
 	self->values.igpu_power_threshold = DEFAULT_IGPU_POWER_THRESHOLD;
 	self->values.inhibit_screensaver = 1; /* Defaults to on */
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
-	self->values.gpu_device = -1; /* 0 is a valid device ID so use -1 to indicate no value */
+	self->values.gpu_device = 0;
 	self->values.nv_powermizer_mode = -1;
 	self->values.nv_core_clock_mhz_offset = -1;
 	self->values.nv_mem_clock_mhz_offset = -1;


### PR DESCRIPTION
This avoids confusion with the default configuration value being `gpu_device=0` (as commented out in the `gamemode.ini` example), but the actual default value being `-1`.

The alternative is to document this behavior and set the commented out value to `-1`, but this makes the setup procedure more complex. The new default behavior suits the 90% use case where there's only one dedicated GPU available.

See https://github.com/FeralInteractive/gamemode/issues/351#issuecomment-1278251075 where I stumbled upon this issue today.