### PR TITLE
Adding CPU core pinning and parking capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently GameMode includes support for optimisations including:
 * Kernel scheduler (`SCHED_ISO`)
 * Screensaver inhibiting
 * GPU performance mode (NVIDIA and AMD), GPU overclocking (NVIDIA)
+* CPU core pinning or parking
 * Custom scripts
 
 GameMode packages are available for Ubuntu, Debian, Solus, Arch, Gentoo, Fedora, OpenSUSE, Mageia and possibly more.

--- a/common/common-cpu.c
+++ b/common/common-cpu.c
@@ -1,0 +1,113 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#include <stdlib.h>
+#include <sched.h>
+#include "common-cpu.h"
+#include "common-logging.h"
+
+char *parse_cpulist (char *cpulist, long *from, long *to)
+{
+	if (!cpulist || *cpulist == '\0')
+		return NULL;
+
+	char *endp;
+	*from = strtol(cpulist, &endp, 10);
+
+	if (endp == cpulist)
+		return NULL;
+
+	if (*endp == '\0' || *endp == ',') {
+		*to = *from;
+
+		if (*endp == '\0')
+			return endp;
+
+		return endp + 1;
+	}
+
+	if (*endp != '-')
+		return NULL;
+
+	cpulist = endp + 1;
+	*to = strtol(cpulist, &endp, 10);
+
+	if (endp == cpulist)
+		return NULL;
+
+	if (*to < *from)
+		return NULL;
+
+	if (*endp == '\0')
+		return endp;
+
+	return endp + 1;
+}
+
+/* Get the vendor for a device */
+/*enum GPUVendor gamemode_get_gpu_vendor(long device)
+{
+	enum GPUVendor vendor = Vendor_Invalid;
+
+	char path[64] = { 0 };
+	if (snprintf(path, 64, "/sys/class/drm/card%ld/device/vendor", device) < 0) {
+		LOG_ERROR("snprintf failed, will not apply gpu optimisations!\n");
+		return Vendor_Invalid;
+	}
+	FILE *file = fopen(path, "r");
+	if (!file) {
+		LOG_ERROR("Couldn't open vendor file at %s, will not apply gpu optimisations!\n", path);
+		return Vendor_Invalid;
+	}
+	char buff[64];
+	bool got_line = fgets(buff, 64, file) != NULL;
+	fclose(file);
+
+	if (got_line) {
+		vendor = strtol(buff, NULL, 0);
+	} else {
+		LOG_ERROR("Couldn't read contents of file %s, will not apply optimisations!\n", path);
+		return Vendor_Invalid;
+	}
+
+	if (!GPUVendorValid(vendor)) {
+		LOG_ERROR("Unknown vendor value (0x%04x) found, cannot apply optimisations!\n",
+		          (unsigned int)vendor);
+		LOG_ERROR("Known values are: 0x%04x (NVIDIA) 0x%04x (AMD) 0x%04x (Intel)\n",
+		          (unsigned int)Vendor_NVIDIA,
+		          (unsigned int)Vendor_AMD,
+		          (unsigned int)Vendor_Intel);
+		return Vendor_Invalid;
+	}
+
+	return vendor;
+}
+*/

--- a/common/common-cpu.c
+++ b/common/common-cpu.c
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "common-cpu.h"
 #include "common-logging.h"
 
-char *parse_cpulist (char *cpulist, long *from, long *to)
+char *parse_cpulist(char *cpulist, long *from, long *to)
 {
 	if (!cpulist || *cpulist == '\0')
 		return NULL;
@@ -71,43 +71,3 @@ char *parse_cpulist (char *cpulist, long *from, long *to)
 
 	return endp + 1;
 }
-
-/* Get the vendor for a device */
-/*enum GPUVendor gamemode_get_gpu_vendor(long device)
-{
-	enum GPUVendor vendor = Vendor_Invalid;
-
-	char path[64] = { 0 };
-	if (snprintf(path, 64, "/sys/class/drm/card%ld/device/vendor", device) < 0) {
-		LOG_ERROR("snprintf failed, will not apply gpu optimisations!\n");
-		return Vendor_Invalid;
-	}
-	FILE *file = fopen(path, "r");
-	if (!file) {
-		LOG_ERROR("Couldn't open vendor file at %s, will not apply gpu optimisations!\n", path);
-		return Vendor_Invalid;
-	}
-	char buff[64];
-	bool got_line = fgets(buff, 64, file) != NULL;
-	fclose(file);
-
-	if (got_line) {
-		vendor = strtol(buff, NULL, 0);
-	} else {
-		LOG_ERROR("Couldn't read contents of file %s, will not apply optimisations!\n", path);
-		return Vendor_Invalid;
-	}
-
-	if (!GPUVendorValid(vendor)) {
-		LOG_ERROR("Unknown vendor value (0x%04x) found, cannot apply optimisations!\n",
-		          (unsigned int)vendor);
-		LOG_ERROR("Known values are: 0x%04x (NVIDIA) 0x%04x (AMD) 0x%04x (Intel)\n",
-		          (unsigned int)Vendor_NVIDIA,
-		          (unsigned int)Vendor_AMD,
-		          (unsigned int)Vendor_Intel);
-		return Vendor_Invalid;
-	}
-
-	return vendor;
-}
-*/

--- a/common/common-cpu.h
+++ b/common/common-cpu.h
@@ -40,5 +40,5 @@ struct GameModeCPUInfo {
 };
 
 /* parses a list of cpu cores in the format "a,b-c,d-e,f" */
-char *parse_cpulist (char *cpulist, long *from, long *to);
+char *parse_cpulist(char *cpulist, long *from, long *to);
 

--- a/common/common-cpu.h
+++ b/common/common-cpu.h
@@ -1,0 +1,44 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#pragma once
+
+/* Storage for CPU info*/
+struct GameModeCPUInfo {
+	size_t num_cpu;
+	int park_or_pin; /* 0 to park 1 to pin */
+	cpu_set_t *online;
+	cpu_set_t *to_keep;
+};
+
+/* parses a list of cpu cores in the format "a,b-c,d-e,f" */
+char *parse_cpulist (char *cpulist, long *from, long *to);
+

--- a/common/common-cpu.h
+++ b/common/common-cpu.h
@@ -31,10 +31,13 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#define IS_CPU_PARK 0
+#define IS_CPU_PIN  1
+
 /* Storage for CPU info*/
 struct GameModeCPUInfo {
 	size_t num_cpu;
-	int park_or_pin; /* 0 to park 1 to pin */
+	int park_or_pin;
 	cpu_set_t *online;
 	cpu_set_t *to_keep;
 };

--- a/common/meson.build
+++ b/common/meson.build
@@ -5,6 +5,7 @@ common_sources = [
     'common-external.c',
     'common-helpers.c',
     'common-gpu.c',
+    'common-cpu.c',
     'common-pidfds.c',
     'common-power.c',
 ]

--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -106,6 +106,9 @@ struct GameModeConfig {
 		long nv_powermizer_mode;
 		char amd_performance_level[CONFIG_VALUE_MAX];
 
+		char cpu_park_cores[CONFIG_VALUE_MAX];
+		char cpu_pin_cores[CONFIG_VALUE_MAX];
+
 		long require_supervisor;
 		char supervisor_whitelist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 		char supervisor_blacklist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
@@ -295,6 +298,12 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = get_long_value(name, value, &self->values.nv_powermizer_mode);
 		} else if (strcmp(name, "amd_performance_level") == 0) {
 			valid = get_string_value(value, self->values.amd_performance_level);
+		}
+	} else if (strcmp(section, "cpu") == 0) {
+		if (strcmp(name, "park_cores") == 0) {
+			valid = get_string_value(value, self->values.cpu_park_cores);
+		} else if (strcmp(name, "pin_cores") == 0) {
+			valid = get_string_value(value, self->values.cpu_pin_cores);
 		}
 	} else if (strcmp(section, "supervisor") == 0) {
 		/* Supervisor subsection */
@@ -793,6 +802,25 @@ void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VA
         char supervisor_blacklist[CONFIG_LIST_MAX][CONFIG_VALUE_MAX];
 */
 DEFINE_CONFIG_GET(require_supervisor)
+
+/*
+ * Get various config info for cpu optimisations
+ */
+void config_get_cpu_park_cores(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self,
+	                     value,
+	                     &self->values.cpu_park_cores,
+	                     sizeof(self->values.cpu_park_cores));
+}
+
+void config_get_cpu_pin_cores(GameModeConfig *self, char value[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self,
+	                     value,
+	                     &self->values.cpu_pin_cores,
+	                     sizeof(self->values.cpu_pin_cores));
+}
 
 /*
  * Checks if the supervisor is whitelisted

--- a/daemon/gamemode-config.h
+++ b/daemon/gamemode-config.h
@@ -118,6 +118,13 @@ long config_get_nv_mem_clock_mhz_offset(GameModeConfig *self);
 long config_get_nv_powermizer_mode(GameModeConfig *self);
 void config_get_amd_performance_level(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
 
+/*
+ * Get various config info for cpu optimisations
+ */
+void config_get_cpu_park_cores(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
+void config_get_cpu_pin_cores(GameModeConfig *self, char value[CONFIG_VALUE_MAX]);
+
+
 /**
  * Functions to get supervisor config permissions
  */

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -649,6 +649,8 @@ static int game_mode_remove_client_optimisations(GameModeContext *self, pid_t cl
 	/* Restore the renice value for the process, expecting it to be our config value */
 	game_mode_apply_renice(self, client, (int)config_get_renice_value(self->config));
 
+	/* Restore the process affinity to all online cores */
+	game_mode_undo_core_pinning(self->cpu, client);
 	return 0;
 }
 
@@ -904,6 +906,7 @@ static void game_mode_reload_config_internal(GameModeContext *self)
 
 	/* Reload the config */
 	config_reload(self->config);
+	game_mode_reconfig_cpu(self->config, &self->cpu);
 
 	/* Re-apply all current optimisations */
 	if (game_mode_context_num_clients(self)) {

--- a/daemon/gamemode-cpu.c
+++ b/daemon/gamemode-cpu.c
@@ -62,7 +62,7 @@ static int read_small_file(char *path, char **buf, size_t *buflen)
 		return 0;
 	}
 
-	fclose (f);
+	fclose(f);
 
 	while (nread > 0 && ((*buf)[nread - 1] == '\n' || (*buf)[nread - 1] == '\r'))
 		nread--;
@@ -195,9 +195,9 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 	int park_or_pin = -1;
 
 	if (pin_cores[0] != '\0') {
-		if (strcasecmp (pin_cores, "no") == 0 || strcasecmp (pin_cores, "false") == 0 || strcmp (pin_cores, "0") == 0) {
+		if (strcasecmp(pin_cores, "no") == 0 || strcasecmp(pin_cores, "false") == 0 || strcmp(pin_cores, "0") == 0) {
 			park_or_pin = -2;
-		} else if (strcasecmp (pin_cores, "yes") == 0 || strcasecmp (pin_cores, "true") == 0 || strcmp (pin_cores, "1") == 0) {
+		} else if (strcasecmp(pin_cores, "yes") == 0 || strcasecmp(pin_cores, "true") == 0 || strcmp(pin_cores, "1") == 0) {
 			pin_cores[0] = '\0';
 			park_or_pin = 1;
 		} else {
@@ -206,12 +206,12 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 	}
 
 	if (park_or_pin < 1 && park_cores[0] != '\0') {
-		if (strcasecmp (park_cores, "no") == 0 || strcasecmp (park_cores, "false") == 0 || strcmp (park_cores, "0") == 0) {
+		if (strcasecmp(park_cores, "no") == 0 || strcasecmp(park_cores, "false") == 0 || strcmp(park_cores, "0") == 0) {
 			if (park_or_pin == -2)
 				return 0;
 
 			park_or_pin = -1;
-		} else if (strcasecmp (park_cores, "yes") == 0 || strcasecmp (park_cores, "true") == 0 || strcmp (park_cores, "1") == 0) {
+		} else if (strcasecmp(park_cores, "yes") == 0 || strcasecmp(park_cores, "true") == 0 || strcmp(park_cores, "1") == 0) {
 			park_cores[0] = '\0';
 			park_or_pin = 0;
 		} else {
@@ -255,12 +255,12 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 	CPU_ZERO_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->to_keep);
 
 	if (park_or_pin == 0 && park_cores[0] != '\0') {
-		if (!walk_string (buf, park_cores, new_info))
+		if (!walk_string(buf, park_cores, new_info))
 			goto error_exit;
 	} else if (park_or_pin == 1 && pin_cores[0] != '\0') {
-		if (!walk_string (buf, pin_cores, new_info))
+		if (!walk_string(buf, pin_cores, new_info))
 			goto error_exit;
-	} else if (!walk_sysfs (buf, &buf2, &buf2len, new_info)) {
+	} else if (!walk_sysfs(buf, &buf2, &buf2len, new_info)) {
 		goto error_exit;
 	}
 
@@ -293,7 +293,7 @@ static int log_state(char *cpulist, int *pos, const long first, const long last)
 {
 	int ret;
 	if (*pos != 0) {
-		ret = snprintf(cpulist+*pos, ARG_MAX - (size_t)*pos, ",");
+		ret = snprintf(cpulist + *pos, ARG_MAX - (size_t)*pos, ",");
 
 		if (ret < 0 || (size_t)ret >= (ARG_MAX - (size_t)*pos)) {
 			LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
@@ -304,9 +304,9 @@ static int log_state(char *cpulist, int *pos, const long first, const long last)
 	}
 
 	if (first == last)
-		ret = snprintf(cpulist+*pos, ARG_MAX - (size_t)*pos, "%ld", first);
+		ret = snprintf(cpulist + *pos, ARG_MAX - (size_t)*pos, "%ld", first);
 	else
-		ret = snprintf(cpulist+*pos, ARG_MAX - (size_t)*pos, "%ld-%ld", first,last);
+		ret = snprintf(cpulist + *pos, ARG_MAX - (size_t)*pos, "%ld-%ld", first,last);
 
 	if (ret < 0 || (size_t)ret >= (ARG_MAX - (size_t)*pos)) {
 		LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
@@ -335,7 +335,7 @@ int game_mode_park_cpu(const GameModeCPUInfo *info)
 			} else if (last + 1 == cpu) {
 				last = cpu;
 			} else {
-				if (!log_state (cpulist, &pos, first, last))
+				if (!log_state(cpulist, &pos, first, last))
 					return 0;
 
 				first = cpu;
@@ -345,7 +345,7 @@ int game_mode_park_cpu(const GameModeCPUInfo *info)
 	}
 
 	if (first != -1)
-		log_state (cpulist, &pos, first, last);
+		log_state(cpulist, &pos, first, last);
 
 	const char *const exec_args[] = {
 		"pkexec", LIBEXECDIR "/cpucorectl", "offline", cpulist, NULL,
@@ -379,7 +379,7 @@ int game_mode_unpark_cpu(const GameModeCPUInfo *info)
 			} else if (last + 1 == cpu) {
 				last = cpu;
 			} else {
-				if (!log_state (cpulist, &pos, first, last))
+				if (!log_state(cpulist, &pos, first, last))
 					return 0;
 
 				first = cpu;
@@ -389,7 +389,7 @@ int game_mode_unpark_cpu(const GameModeCPUInfo *info)
 	}
 
 	if (first != -1)
-		log_state (cpulist, &pos, first, last);
+		log_state(cpulist, &pos, first, last);
 
 	const char *const exec_args[] = {
 		"pkexec", LIBEXECDIR "/cpucorectl", "online", cpulist, NULL,

--- a/daemon/gamemode-cpu.c
+++ b/daemon/gamemode-cpu.c
@@ -45,7 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "build-config.h"
 
-static int read_small_file (char *path, char **buf, size_t *buflen)
+static int read_small_file(char *path, char **buf, size_t *buflen)
 {
 	FILE *f = fopen(path, "r");
 
@@ -72,7 +72,7 @@ static int read_small_file (char *path, char **buf, size_t *buflen)
 	return 1;
 }
 
-static int walk_sysfs (char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo *info)
+static int walk_sysfs(char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo *info)
 {
 	char path[PATH_MAX];
 	unsigned long long max_cache = 0, max_freq = 0;
@@ -151,7 +151,7 @@ static int walk_sysfs (char *cpulist, char **buf, size_t *buflen, GameModeCPUInf
 	return 1;
 }
 
-static int walk_string (char *cpulist, char *config_cpulist, GameModeCPUInfo *info)
+static int walk_string(char *cpulist, char *config_cpulist, GameModeCPUInfo *info)
 {
 	long from, to;
 
@@ -289,7 +289,7 @@ error_exit:
 	return -1;
 }
 
-static int log_state (char *cpulist, int *pos, const long first, const long last)
+static int log_state(char *cpulist, int *pos, const long first, const long last)
 {
 	int ret;
 	if (*pos != 0) {

--- a/daemon/gamemode-cpu.c
+++ b/daemon/gamemode-cpu.c
@@ -433,7 +433,7 @@ void game_mode_apply_core_pinning(const GameModeCPUInfo *info, const pid_t clien
 
 void game_mode_free_cpu(GameModeCPUInfo **info)
 {
-	if (!(*info)) {
+	if ((*info)) {
 		CPU_FREE((*info)->online);
 		(*info)->online = NULL;
 

--- a/daemon/gamemode-cpu.c
+++ b/daemon/gamemode-cpu.c
@@ -35,8 +35,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sched.h>
 #include <linux/limits.h>
 
-#include "common-external.h"
 #include "common-cpu.h"
+#include "common-external.h"
 #include "common-helpers.h"
 #include "common-logging.h"
 
@@ -86,12 +86,13 @@ static int walk_sysfs(char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo
 			CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online);
 
 			/* check for L3 cache non-uniformity among the cores */
-			int ret = snprintf(path, PATH_MAX, "/sys/devices/system/cpu/cpu%ld/cache/index3/size", cpu);
+			int ret = 
+			    snprintf(path, PATH_MAX, "/sys/devices/system/cpu/cpu%ld/cache/index3/size", cpu);
 
 			if (ret > 0 && ret < PATH_MAX) {
 				if (read_small_file(path, buf, buflen)) {
 					char *endp;
-					unsigned long long cache_size = strtoull (*buf, &endp, 10);
+					unsigned long long cache_size = strtoull(*buf, &endp, 10);
 
 					if (*endp == 'K') {
 						cache_size *= 1024;
@@ -115,11 +116,14 @@ static int walk_sysfs(char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo
 			}
 
 			/* check for frequency non-uniformity among the cores */
-			ret = snprintf(path, PATH_MAX, "/sys/devices/system/cpu/cpu%ld/cpufreq/cpuinfo_max_freq", cpu);
+			ret = snprintf(path,
+				       PATH_MAX, 
+				       "/sys/devices/system/cpu/cpu%ld/cpufreq/cpuinfo_max_freq", 
+				       cpu);
 
 			if (ret > 0 && ret < PATH_MAX) {
 				if (read_small_file(path, buf, buflen)) {
-					unsigned long long freq = strtoull (*buf, NULL, 10);
+					unsigned long long freq = strtoull(*buf, NULL, 10);
 					unsigned long long cutoff = (freq * 5) / 100;
 
 					if (freq > max_freq) {
@@ -136,13 +140,15 @@ static int walk_sysfs(char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo
 		}
 	}
 
-	if (CPU_EQUAL_S(CPU_ALLOC_SIZE(info->num_cpu), info->online, info->to_keep) || CPU_COUNT_S(CPU_ALLOC_SIZE(info->num_cpu), info->to_keep) == 0) {
+	if (CPU_EQUAL_S(CPU_ALLOC_SIZE(info->num_cpu), info->online, info->to_keep) || 
+	    CPU_COUNT_S(CPU_ALLOC_SIZE(info->num_cpu), info->to_keep) == 0) {
 		LOG_MSG("cpu L3 cache was uniform, this is not a x3D with multiple chiplets\n");
 
 		CPU_FREE(info->to_keep);
 		info->to_keep = freq_cores;
 
-		if (CPU_EQUAL_S(CPU_ALLOC_SIZE(info->num_cpu), info->online, info->to_keep) || CPU_COUNT_S(CPU_ALLOC_SIZE(info->num_cpu), info->to_keep) == 0)
+		if (CPU_EQUAL_S(CPU_ALLOC_SIZE(info->num_cpu), info->online, info->to_keep) || 
+		    CPU_COUNT_S(CPU_ALLOC_SIZE(info->num_cpu), info->to_keep) == 0)
 			LOG_MSG("cpu frequency was uniform, this is not a big.LITTLE type of system\n");
 	} else {
 		CPU_FREE(freq_cores);
@@ -195,9 +201,11 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 	int park_or_pin = -1;
 
 	if (pin_cores[0] != '\0') {
-		if (strcasecmp(pin_cores, "no") == 0 || strcasecmp(pin_cores, "false") == 0 || strcmp(pin_cores, "0") == 0) {
+		if (strcasecmp(pin_cores, "no") == 0 || strcasecmp(pin_cores, "false") == 0 || 
+		    strcmp(pin_cores, "0") == 0) {
 			park_or_pin = -2;
-		} else if (strcasecmp(pin_cores, "yes") == 0 || strcasecmp(pin_cores, "true") == 0 || strcmp(pin_cores, "1") == 0) {
+		} else if (strcasecmp(pin_cores, "yes") == 0 || strcasecmp(pin_cores, "true") == 0 || 
+			   strcmp(pin_cores, "1") == 0) {
 			pin_cores[0] = '\0';
 			park_or_pin = 1;
 		} else {
@@ -206,12 +214,14 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 	}
 
 	if (park_or_pin < 1 && park_cores[0] != '\0') {
-		if (strcasecmp(park_cores, "no") == 0 || strcasecmp(park_cores, "false") == 0 || strcmp(park_cores, "0") == 0) {
+		if (strcasecmp(park_cores, "no") == 0 || strcasecmp(park_cores, "false") == 0 || 
+		    strcmp(park_cores, "0") == 0) {
 			if (park_or_pin == -2)
 				return 0;
 
 			park_or_pin = -1;
-		} else if (strcasecmp(park_cores, "yes") == 0 || strcasecmp(park_cores, "true") == 0 || strcmp(park_cores, "1") == 0) {
+		} else if (strcasecmp(park_cores, "yes") == 0 || strcasecmp(park_cores, "true") == 0 || 
+			   strcmp(park_cores, "1") == 0) {
 			park_cores[0] = '\0';
 			park_or_pin = 0;
 		} else {
@@ -264,7 +274,8 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 		goto error_exit;
 	}
 
-	if (park_or_pin == 0 && CPU_EQUAL_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->online, new_info->to_keep)) {
+	if (park_or_pin == 0 && 
+	    CPU_EQUAL_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->online, new_info->to_keep)) {
 		game_mode_free_cpu(&new_info);
 		LOG_MSG("I can find no reason to perform core parking on this system!\n");
 		goto error_exit;
@@ -272,20 +283,22 @@ int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
 
 	if (CPU_COUNT_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->to_keep) < 4) {
 		game_mode_free_cpu(&new_info);
-		LOG_MSG("logic or config would result in less than 4 active cores, will not apply cpu core parking/pinning!\n");
+		LOG_MSG(
+		    "logic or config would result in less than 4 active cores, will not apply cpu core "
+		    "parking/pinning!\n");
 		goto error_exit;
 	}
 
 	*info = new_info;
 
 early_exit:
-	free (buf);
-	free (buf2);
+	free(buf);
+	free(buf2);
 	return 0;
 
 error_exit:
-	free (buf);
-	free (buf2);
+	free(buf);
+	free(buf2);
 	return -1;
 }
 
@@ -306,7 +319,7 @@ static int log_state(char *cpulist, int *pos, const long first, const long last)
 	if (first == last)
 		ret = snprintf(cpulist + *pos, ARG_MAX - (size_t)*pos, "%ld", first);
 	else
-		ret = snprintf(cpulist + *pos, ARG_MAX - (size_t)*pos, "%ld-%ld", first,last);
+		ret = snprintf(cpulist + *pos, ARG_MAX - (size_t)*pos, "%ld-%ld", first, last);
 
 	if (ret < 0 || (size_t)ret >= (ARG_MAX - (size_t)*pos)) {
 		LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
@@ -328,7 +341,8 @@ int game_mode_park_cpu(const GameModeCPUInfo *info)
 	int pos = 0;
 
 	for (long cpu = 0; cpu < (long)(info->num_cpu); cpu++) {
-		if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online) && !CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep)) {
+		if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online) && 
+		    !CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep)) {
 			if (first == -1) {
 				first = cpu;
 				last = cpu;
@@ -372,7 +386,8 @@ int game_mode_unpark_cpu(const GameModeCPUInfo *info)
 	int pos = 0;
 
 	for (long cpu = 0; cpu < (long)(info->num_cpu); cpu++) {
-		if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online) && !CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep)) {
+		if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online) && 
+		    !CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep)) {
 			if (first == -1) {
 				first = cpu;
 				last = cpu;

--- a/daemon/gamemode-cpu.c
+++ b/daemon/gamemode-cpu.c
@@ -1,0 +1,409 @@
+
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#define _GNU_SOURCE
+
+#include <sched.h>
+#include <linux/limits.h>
+
+#include "common-external.h"
+#include "common-cpu.h"
+#include "common-helpers.h"
+#include "common-logging.h"
+
+#include "gamemode.h"
+#include "gamemode-config.h"
+
+#include "build-config.h"
+
+static int read_small_file (char *path, char **buf, size_t *buflen)
+{
+	FILE *f = fopen(path, "r");
+
+	if (!f) {
+		LOG_ERROR("Couldn't open file at %s (%s), will not apply cpu core parking!\n", path, strerror(errno));
+		return 0;
+	}
+
+	ssize_t nread = getline(buf, buflen, f);
+
+	if (nread == -1) {
+		LOG_ERROR("Couldn't read file at %s (%s), will not apply cpu core parking!\n", path, strerror(errno));
+		fclose(f);
+		return 0;
+	}
+
+	fclose (f);
+
+	while (nread > 0 && ((*buf)[nread - 1] == '\n' || (*buf)[nread - 1] == '\r'))
+		nread--;
+
+	(*buf)[nread] = '\0';
+
+	return 1;
+}
+
+static int walk_sysfs (char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo *info)
+{
+	char path[PATH_MAX];
+	unsigned long long max_cache = 0;
+	long from, to;
+
+	char *list = cpulist;
+	while ((list = parse_cpulist(list, &from, &to))) {
+		for (long cpu = from; cpu < to + 1; cpu++) {
+			int ret = snprintf(path, PATH_MAX, "/sys/devices/system/cpu/cpu%ld/cache/index3/size", cpu);
+			if (ret < 0 || ret >= PATH_MAX) {
+				LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
+				return 0;
+			}
+
+			if (!read_small_file(path, buf, buflen))
+				return 0;
+
+			char *endp;
+			unsigned long long cache_size = strtoull (*buf, &endp, 10);
+
+			if (*endp == 'K') {
+				cache_size *= 1024;
+			} else if (*endp == 'M') {
+				cache_size *= 1024 * 1024;
+			} else if (*endp == 'G') {
+				cache_size *= 1024 * 1024 * 1024;
+			} else if (*endp != '\0') {
+				LOG_ERROR("cpu L3 cache size (%s) is silly, will not apply cpu core parking!\n", *buf);
+				return 0;
+			}
+
+			if (cache_size > max_cache) {
+				max_cache = cache_size;
+				CPU_ZERO_S(CPU_ALLOC_SIZE(info->num_cpu), info->to_keep);
+			}
+
+			if (cache_size == max_cache)
+				CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep);
+
+			CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online);
+		}
+	}
+
+	return 1;
+}
+
+static int walk_string (char *cpulist, char *config_cpulist, GameModeCPUInfo *info)
+{
+	long from, to;
+
+	char *list = cpulist;
+	while ((list = parse_cpulist(list, &from, &to))) {
+		for (long cpu = from; cpu < to + 1; cpu++) {
+			CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online);
+
+			if (info->park_or_pin == 0)
+				CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep);
+		}
+	}
+
+	list = config_cpulist;
+	while ((list = parse_cpulist(list, &from, &to))) {
+		for (long cpu = from; cpu < to + 1; cpu++) {
+			if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online)) {
+				if (info->park_or_pin == 0)
+					CPU_CLR_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep);
+				else
+					CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep);
+			}
+		}
+	}
+
+	return 1;
+}
+
+/**
+ * Attempts to identify the current in use CPU information
+ */
+int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info)
+{
+	/* Verify input, this is programmer error */
+	if (!info || *info)
+		FATAL_ERROR("Invalid GameModeCPUInfo passed to %s", __func__);
+
+	/* Early out if we have this feature turned off */
+	char park_cores[CONFIG_VALUE_MAX];
+	char pin_cores[CONFIG_VALUE_MAX];
+	config_get_cpu_park_cores(config, park_cores);
+	config_get_cpu_pin_cores(config, pin_cores);
+
+	int park_or_pin = -1;
+
+	if (pin_cores[0] != '\0') {
+		if (strcasecmp (pin_cores, "no") == 0 || strcasecmp (pin_cores, "false") == 0 || strcmp (pin_cores, "0") == 0) {
+			park_or_pin = -2;
+		} else if (strcasecmp (pin_cores, "yes") == 0 || strcasecmp (pin_cores, "true") == 0 || strcmp (pin_cores, "1") == 0) {
+			pin_cores[0] = '\0';
+			park_or_pin = 1;
+		} else {
+			park_or_pin = 1;
+		}
+	}
+
+	if (park_or_pin < 1 && park_cores[0] != '\0') {
+		if (strcasecmp (park_cores, "no") == 0 || strcasecmp (park_cores, "false") == 0 || strcmp (park_cores, "0") == 0) {
+			if (park_or_pin == -2)
+				return 0;
+
+			park_or_pin = -1;
+		} else if (strcasecmp (park_cores, "yes") == 0 || strcasecmp (park_cores, "true") == 0 || strcmp (park_cores, "1") == 0) {
+			park_cores[0] = '\0';
+			park_or_pin = 0;
+		} else {
+			park_or_pin = 0;
+		}
+	}
+
+	/* always default to pin */
+	if (park_or_pin < 0)
+		park_or_pin = 1;
+
+	char *buf = NULL, *buf2 = NULL;
+	size_t buflen = 0, buf2len = 0;
+
+	/* first we find which cores are online, this also helps us to determine the max
+	 * cpu core number that we need to allocate the cpulist later */
+	if (!read_small_file("/sys/devices/system/cpu/online", &buf, &buflen))
+		goto error_exit;
+
+	long from, to, max = 0;
+	char *s = buf;
+	while ((s = parse_cpulist(s, &from, &to))) {
+		if (to > max)
+			max = to;
+	}
+
+	/* either parsing failed or we have only a single core, in either case
+	 * we cannot optimize anyway */
+	if (max == 0)
+		goto early_exit;
+
+	GameModeCPUInfo *new_info = malloc(sizeof(GameModeCPUInfo));
+	memset(new_info, 0, sizeof(GameModeCPUInfo));
+
+	new_info->num_cpu = (size_t)(max + 1);
+	new_info->park_or_pin = park_or_pin;
+	new_info->online = CPU_ALLOC(new_info->num_cpu);
+	new_info->to_keep = CPU_ALLOC(new_info->num_cpu);
+
+	CPU_ZERO_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->online);
+	CPU_ZERO_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->to_keep);
+
+	if (park_or_pin == 0 && park_cores[0] != '\0') {
+		if (!walk_string (buf, park_cores, new_info))
+			goto error_exit;
+	} else if (park_or_pin == 1 && pin_cores[0] != '\0') {
+		if (!walk_string (buf, pin_cores, new_info))
+			goto error_exit;
+	} else if (!walk_sysfs (buf, &buf2, &buf2len, new_info)) {
+		goto error_exit;
+	}
+
+	if (park_or_pin == 0 && CPU_EQUAL_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->online, new_info->to_keep)) {
+		game_mode_free_cpu(&new_info);
+		LOG_MSG("cpu L3 cache is uniform, will not apply cpu core parking!\n");
+		goto error_exit;
+	}
+
+	if (CPU_COUNT_S(CPU_ALLOC_SIZE(new_info->num_cpu), new_info->to_keep) == 0) {
+		game_mode_free_cpu(&new_info);
+		LOG_MSG("logic or config wanted to park/unpin every single cpu core, will not apply cpu core parking/pinning!\n");
+		goto error_exit;
+	}
+
+	/* Give back the new cpu info */
+	*info = new_info;
+
+early_exit:
+	free (buf);
+	free (buf2);
+	return 0;
+
+error_exit:
+	free (buf);
+	free (buf2);
+	return -1;
+}
+
+static int log_state (char *cpulist, int *pos, const long first, const long last)
+{
+	int ret;
+	if (*pos != 0) {
+		ret = snprintf(cpulist+*pos, ARG_MAX - (size_t)*pos, ",");
+
+		if (ret < 0 || (size_t)ret >= (ARG_MAX - (size_t)*pos)) {
+			LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
+			return 0;
+		}
+
+		*pos += ret;
+	}
+
+	if (first == last)
+		ret = snprintf(cpulist+*pos, ARG_MAX - (size_t)*pos, "%ld", first);
+	else
+		ret = snprintf(cpulist+*pos, ARG_MAX - (size_t)*pos, "%ld-%ld", first,last);
+
+	if (ret < 0 || (size_t)ret >= (ARG_MAX - (size_t)*pos)) {
+		LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
+		return 0;
+	}
+
+	*pos += ret;
+	return 1;
+}
+
+/**
+ * Park the unwanted cpu cores when gamemode is active
+ */
+int game_mode_park_cpu(const GameModeCPUInfo *info)
+{
+	if (!info || info->park_or_pin == 1)
+		return 0;
+
+	long first = -1, last = -1;
+
+	char cpulist[ARG_MAX];
+	int pos = 0;
+
+	for (long cpu = 0; cpu < (long)(info->num_cpu); cpu++) {
+		if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online) && !CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep)) {
+			if (first == -1) {
+				first = cpu;
+				last = cpu;
+			} else if (last + 1 == cpu) {
+				last = cpu;
+			} else {
+				if (!log_state (cpulist, &pos, first, last))
+					return 0;
+
+				first = cpu;
+				last = cpu;
+			}
+		}
+	}
+
+	if (first != -1)
+		log_state (cpulist, &pos, first, last);
+
+	const char *const exec_args[] = {
+		"pkexec", LIBEXECDIR "/cpucorectl", "offline", cpulist, NULL,
+	};
+
+	LOG_MSG("Requesting parking of cores %s\n", cpulist);
+	int ret = run_external_process(exec_args, NULL, -1);
+	if (ret != 0) {
+		LOG_ERROR("Failed to park cpu cores\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * Restore the parked cpu cores when gamemode is disabled
+ */
+int game_mode_unpark_cpu(const GameModeCPUInfo *info)
+{
+	if (!info || info->park_or_pin == 1)
+		return 0;
+
+	long first = -1, last = -1;
+
+	char cpulist[ARG_MAX];
+	int pos = 0;
+
+	for (long cpu = 0; cpu < (long)(info->num_cpu); cpu++) {
+		if (CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->online) && !CPU_ISSET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep)) {
+			if (first == -1) {
+				first = cpu;
+				last = cpu;
+			} else if (last + 1 == cpu) {
+				last = cpu;
+			} else {
+				if (!log_state (cpulist, &pos, first, last))
+					return 0;
+
+				first = cpu;
+				last = cpu;
+			}
+		}
+	}
+
+	if (first != -1)
+		log_state (cpulist, &pos, first, last);
+
+	const char *const exec_args[] = {
+		"pkexec", LIBEXECDIR "/cpucorectl", "online", cpulist, NULL,
+	};
+
+	LOG_MSG("Requesting unparking of cores %s\n", cpulist);
+	int ret = run_external_process(exec_args, NULL, -1);
+	if (ret != 0) {
+		LOG_ERROR("Failed to unpark cpu cores\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+void game_mode_apply_core_pinning(const GameModeCPUInfo *info, const pid_t client)
+{
+	if (!info || info->park_or_pin == 0)
+		return;
+
+	if (sched_setaffinity(client, CPU_ALLOC_SIZE(info->num_cpu), info->to_keep) != 0)
+		LOG_ERROR("Failed to pin process: %s\n", strerror(errno));
+}
+
+/* Simply used to free the CPU info object */
+void game_mode_free_cpu(GameModeCPUInfo **info)
+{
+	if (!(*info)) {
+		CPU_FREE((*info)->online);
+		(*info)->online = NULL;
+
+		CPU_FREE((*info)->to_keep);
+		(*info)->to_keep = NULL;
+
+		free(*info);
+		*info = NULL;
+	}
+}
+

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -209,9 +209,11 @@ int game_mode_get_gpu(GameModeGPUInfo *info);
 typedef struct GameModeCPUInfo GameModeCPUInfo;
 int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info);
 void game_mode_free_cpu(GameModeCPUInfo **info);
+void game_mode_reconfig_cpu(GameModeConfig *config, GameModeCPUInfo **info);
 int game_mode_park_cpu(const GameModeCPUInfo *info);
 int game_mode_unpark_cpu(const GameModeCPUInfo *info);
 void game_mode_apply_core_pinning(const GameModeCPUInfo *info, const pid_t client);
+void game_mode_undo_core_pinning(const GameModeCPUInfo *info, const pid_t client);
 
 /** gamemode-dbus.c
  * Provides an API interface for using dbus

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -212,7 +212,7 @@ void game_mode_free_cpu(GameModeCPUInfo **info);
 void game_mode_reconfig_cpu(GameModeConfig *config, GameModeCPUInfo **info);
 int game_mode_park_cpu(const GameModeCPUInfo *info);
 int game_mode_unpark_cpu(const GameModeCPUInfo *info);
-void game_mode_apply_core_pinning(const GameModeCPUInfo *info, const pid_t client);
+void game_mode_apply_core_pinning(const GameModeCPUInfo *info, const pid_t client, const bool be_silent);
 void game_mode_undo_core_pinning(const GameModeCPUInfo *info, const pid_t client);
 
 /** gamemode-dbus.c

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -203,6 +203,16 @@ void game_mode_free_gpu(GameModeGPUInfo **info);
 int game_mode_apply_gpu(const GameModeGPUInfo *info);
 int game_mode_get_gpu(GameModeGPUInfo *info);
 
+/** gamemode-cpu.c
+ * Provides internal functions to apply optimisations to cpus
+ */
+typedef struct GameModeCPUInfo GameModeCPUInfo;
+int game_mode_initialise_cpu(GameModeConfig *config, GameModeCPUInfo **info);
+void game_mode_free_cpu(GameModeCPUInfo **info);
+int game_mode_park_cpu(const GameModeCPUInfo *info);
+int game_mode_unpark_cpu(const GameModeCPUInfo *info);
+void game_mode_apply_core_pinning(const GameModeCPUInfo *info, const pid_t client);
+
 /** gamemode-dbus.c
  * Provides an API interface for using dbus
  */

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -7,6 +7,7 @@ daemon_sources = [
     'gamemode-wine.c',
     'gamemode-tests.c',
     'gamemode-gpu.c',
+    'gamemode-cpu.c',
     'gamemode-dbus.c',
     'gamemode-config.c',
 ]

--- a/data/polkit/actions/com.feralinteractive.GameMode.policy.in
+++ b/data/polkit/actions/com.feralinteractive.GameMode.policy.in
@@ -35,4 +35,16 @@
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 
+  <action id="com.feralinteractive.GameMode.cpu-helper">
+    <description>Modify the CPU core states</description>
+    <message>Authentication is required to modify the CPU core states</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>no</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@LIBEXECDIR@/cpucorectl</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+
 </policyconfig>

--- a/data/polkit/rules.d/gamemode.rules.in
+++ b/data/polkit/rules.d/gamemode.rules.in
@@ -4,7 +4,8 @@
  */
 polkit.addRule(function (action, subject) {
     if ((action.id == "com.feralinteractive.GameMode.governor-helper" ||
-         action.id == "com.feralinteractive.GameMode.gpu-helper") &&
+         action.id == "com.feralinteractive.GameMode.gpu-helper" ||
+         action.id == "com.feralinteractive.GameMode.cpu-helper") &&
         subject.isInGroup("@GAMEMODE_PRIVILEGED_GROUP@"))
     {
         return polkit.Result.YES;

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -75,6 +75,15 @@ inhibit_screensaver=1
 ; This corresponds to power_dpm_force_performance_level, "manual" is not supported for now
 ;amd_performance_level=high
 
+[cpu]
+; Parking or Pinning can be enabled with either "yes", "true" or "1" and disabled with "no", "false" or "0".
+; Either can also be set to a specific list of cores to park or pin, comma separated list where "-" denotes
+; a range. E.g "park_cores=1,8-15" would park cores 1 and 8 to 15.
+; The default is uncommented is to disable parking but enable pinning. If either is enabled the code will
+; currently only properly autodetect Ryzen 7900x3d and 7950x3d
+;park_cores=no
+;pin_cores=yes
+
 [supervisor]
 ; This section controls the new gamemode functions gamemode_request_start_for and gamemode_request_end_for
 ; The whilelist and blacklist control which supervisor programs are allowed to make the above requests

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -80,7 +80,7 @@ inhibit_screensaver=1
 ; Either can also be set to a specific list of cores to park or pin, comma separated list where "-" denotes
 ; a range. E.g "park_cores=1,8-15" would park cores 1 and 8 to 15.
 ; The default is uncommented is to disable parking but enable pinning. If either is enabled the code will
-; currently only properly autodetect Ryzen 7900x3d and 7950x3d
+; currently only properly autodetect Ryzen 7900x3d, 7950x3d and Intel CPU:s with E- and P-cores.
 ;park_cores=no
 ;pin_cores=yes
 

--- a/util/cpucorectl.c
+++ b/util/cpucorectl.c
@@ -91,7 +91,8 @@ static int set_state(char *cpulist, int state)
 				/* on some systems one cannot park core #0 */
 				if (cpu != 0) {
 					if (state == '0') {
-						LOG_ERROR("unable to park core #%ld, will not apply cpu core parking!\n", cpu);
+						LOG_ERROR("unable to park core #%ld, will not apply cpu core parking!\n", 
+							  cpu);
 						return -1;
 					}
 
@@ -104,7 +105,7 @@ static int set_state(char *cpulist, int state)
 				} else if (last + 1 == cpu) {
 					last = cpu;
 				} else {
-					log_state (state, first, last);
+					log_state(state, first, last);
 					first = cpu;
 					last = cpu;
 				}

--- a/util/cpucorectl.c
+++ b/util/cpucorectl.c
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "common-cpu.h"
 #include "common-logging.h"
 
-static int write_state (char *path, int state)
+static int write_state(char *path, int state)
 {
 	FILE *f = fopen(path, "w");
 
@@ -57,7 +57,7 @@ static int write_state (char *path, int state)
 	return 1;
 }
 
-static void log_state (const int state, const long first, const long last)
+static void log_state(const int state, const long first, const long last)
 {
 	if (state == '0') {
 		if (first == last)
@@ -72,7 +72,7 @@ static void log_state (const int state, const long first, const long last)
 	}
 }
 
-static int set_state (char *cpulist, int state)
+static int set_state(char *cpulist, int state)
 {
 	char path[PATH_MAX];
 	long from, to;

--- a/util/cpucorectl.c
+++ b/util/cpucorectl.c
@@ -1,0 +1,140 @@
+/*
+
+Copyright (c) 2017-2019, Feral Interactive
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#define _GNU_SOURCE
+
+#include <sched.h>
+#include <unistd.h>
+#include <linux/limits.h>
+
+#include "common-cpu.h"
+#include "common-logging.h"
+
+static int write_state (char *path, int state)
+{
+	FILE *f = fopen(path, "w");
+
+	if (!f) {
+		LOG_ERROR("Couldn't open file at %s (%s)\n", path, strerror(errno));
+		return 0;
+	}
+
+	if (putc (state, f) == EOF) {
+		LOG_ERROR("Couldn't write to file at %s (%s)\n", path, strerror(errno));
+		fclose (f);
+		return 0;
+	}
+
+	fclose (f);
+	return 1;
+}
+
+static void log_state (const int state, const long first, const long last)
+{
+	if (state == '0') {
+		if (first == last)
+			LOG_MSG("parked core %ld\n", first);
+		else
+			LOG_MSG("parked cores %ld - %ld\n", first, last);
+	} else {
+		if (first == last)
+			LOG_MSG("unparked core %ld\n", first);
+		else
+			LOG_MSG("unparked cores %ld - %ld\n", first, last);
+	}
+}
+
+static int set_state (char *cpulist, int state)
+{
+	char path[PATH_MAX];
+	long from, to;
+	char *list = cpulist;
+
+	long first = -1, last = -1;
+
+	while ((list = parse_cpulist(list, &from, &to))) {
+		for (long cpu = from; cpu < to + 1; cpu++) {
+			if (snprintf(path, PATH_MAX, "/sys/devices/system/cpu/cpu%ld/online", cpu) < 0) {
+				LOG_ERROR("snprintf failed, will not apply cpu core parking!\n");
+				return 0;
+			}
+
+			if (!write_state (path, state)) {
+				/* on some systems one cannot park core #0 */
+				if (cpu != 0) {
+					if (state == '0') {
+						LOG_ERROR("unable to park core #%ld, will not apply cpu core parking!\n", cpu);
+						return -1;
+					}
+
+					LOG_ERROR("unable to unpark core #%ld\n", cpu);
+				}
+			} else {
+				if (first == -1) {
+					first = cpu;
+					last = cpu;
+				} else if (last + 1 == cpu) {
+					last = cpu;
+				} else {
+					log_state (state, first, last);
+					first = cpu;
+					last = cpu;
+				}
+			}
+		}
+	}
+
+	if (first != -1)
+		log_state (state, first, last);
+
+	return 1;
+}
+
+int main(int argc, char *argv[])
+{
+	if (geteuid() != 0) {
+		LOG_ERROR("This program must be run as root\n");
+		return EXIT_FAILURE;
+	}
+
+	if (argc == 3 && strncmp(argv[1], "online", 6) == 0) {
+		if (!set_state (argv[2], '1'))
+			return EXIT_FAILURE;
+	} else if (argc == 3 && strncmp(argv[1], "offline", 7) == 0) {
+		if (!set_state (argv[2], '0'))
+			return EXIT_FAILURE;
+	} else {
+		fprintf(stderr, "usage: cpucorectl [online]|[offline] VALUE]\n");
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/util/cpucorectl.c
+++ b/util/cpucorectl.c
@@ -47,13 +47,13 @@ static int write_state(char *path, int state)
 		return 0;
 	}
 
-	if (putc (state, f) == EOF) {
+	if (putc(state, f) == EOF) {
 		LOG_ERROR("Couldn't write to file at %s (%s)\n", path, strerror(errno));
-		fclose (f);
+		fclose(f);
 		return 0;
 	}
 
-	fclose (f);
+	fclose(f);
 	return 1;
 }
 
@@ -87,7 +87,7 @@ static int set_state(char *cpulist, int state)
 				return 0;
 			}
 
-			if (!write_state (path, state)) {
+			if (!write_state(path, state)) {
 				/* on some systems one cannot park core #0 */
 				if (cpu != 0) {
 					if (state == '0') {
@@ -113,7 +113,7 @@ static int set_state(char *cpulist, int state)
 	}
 
 	if (first != -1)
-		log_state (state, first, last);
+		log_state(state, first, last);
 
 	return 1;
 }
@@ -126,10 +126,10 @@ int main(int argc, char *argv[])
 	}
 
 	if (argc == 3 && strncmp(argv[1], "online", 6) == 0) {
-		if (!set_state (argv[2], '1'))
+		if (!set_state(argv[2], '1'))
 			return EXIT_FAILURE;
 	} else if (argc == 3 && strncmp(argv[1], "offline", 7) == 0) {
-		if (!set_state (argv[2], '0'))
+		if (!set_state(argv[2], '0'))
 			return EXIT_FAILURE;
 	} else {
 		fprintf(stderr, "usage: cpucorectl [online]|[offline] VALUE]\n");

--- a/util/meson.build
+++ b/util/meson.build
@@ -28,3 +28,18 @@ gpuclockctl = executable(
     install: true,
     install_dir: path_libexecdir,
 )
+
+# Small target util to park and unpark cores
+cpucorectl_sources = [
+    'cpucorectl.c',
+]
+
+cpucorectl = executable(
+    'cpucorectl',
+    sources: cpucorectl_sources,
+    dependencies: [
+        link_daemon_common,
+    ],
+    install: true,
+    install_dir: path_libexecdir,
+)


### PR DESCRIPTION
First attempt at merging this patch set that adds cpu core pinning and parking capability. There is automatic logic that will try to detect if running on a CPU with non-uniform L3 cache (say 7900x3D or 7950x3D) or on a CPU with non-uniform frequencies (say Intel Alder Lake, Raptor Lake and so on with E-cores and P-cores).

By default the code will pin all the threads of the game on the cores with the better L3 or frequency but can also be configured to completely park the less desired cores (akin to how the xbox gamebar works in Windows on the 7900x3D and 7950x3D). Parking requires the aid of an new helper utility, cpucorectl, under polkit since that requires root privileges.

If logic fails or is inadequate then it is also possible to manually set which cores to pin to or which cores to park in the config file. There is also a built in safety check to make sure that the user/logic does not disable all cores by making sure that at least 4 cores have to be available for the game.