### PR TITLE
Allow user to disable the Linux kernel split lock mitigation

### DIFF
--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -375,7 +375,7 @@ static void load_config_files(GameModeConfig *self)
 	/* Set some non-zero defaults */
 	self->values.igpu_power_threshold = DEFAULT_IGPU_POWER_THRESHOLD;
 	self->values.inhibit_screensaver = 1; /* Defaults to on */
-	self->values.disable_splitlock = 1; /* Defaults to on */
+	self->values.disable_splitlock = 1;	/* Defaults to on */
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = 0;
 	self->values.nv_powermizer_mode = -1;

--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -375,7 +375,7 @@ static void load_config_files(GameModeConfig *self)
 	/* Set some non-zero defaults */
 	self->values.igpu_power_threshold = DEFAULT_IGPU_POWER_THRESHOLD;
 	self->values.inhibit_screensaver = 1; /* Defaults to on */
-	self->values.disable_splitlock = 1;	/* Defaults to on */
+	self->values.disable_splitlock = 1;   /* Defaults to on */
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = 0;
 	self->values.nv_powermizer_mode = -1;

--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -97,6 +97,8 @@ struct GameModeConfig {
 
 		long inhibit_screensaver;
 
+		long disable_splitlock;
+
 		long reaper_frequency;
 
 		char apply_gpu_optimisations[CONFIG_VALUE_MAX];
@@ -274,6 +276,8 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = get_string_value(value, self->values.ioprio);
 		} else if (strcmp(name, "inhibit_screensaver") == 0) {
 			valid = get_long_value(name, value, &self->values.inhibit_screensaver);
+		} else if (strcmp(name, "disable_splitlock") == 0) {
+			valid = get_long_value(name, value, &self->values.disable_splitlock);
 		}
 	} else if (strcmp(section, "gpu") == 0) {
 		/* Protect the user - don't allow these config options from unsafe config locations */
@@ -371,6 +375,7 @@ static void load_config_files(GameModeConfig *self)
 	/* Set some non-zero defaults */
 	self->values.igpu_power_threshold = DEFAULT_IGPU_POWER_THRESHOLD;
 	self->values.inhibit_screensaver = 1; /* Defaults to on */
+	self->values.disable_splitlock = 1; /* Defaults to on */
 	self->values.reaper_frequency = DEFAULT_REAPER_FREQ;
 	self->values.gpu_device = 0;
 	self->values.nv_powermizer_mode = -1;
@@ -637,6 +642,16 @@ bool config_get_inhibit_screensaver(GameModeConfig *self)
 {
 	long val;
 	memcpy_locked_config(self, &val, &self->values.inhibit_screensaver, sizeof(long));
+	return val == 1;
+}
+
+/*
+ * Gets the disable splitlock setting
+ */
+bool config_get_disable_splitlock(GameModeConfig *self)
+{
+	long val;
+	memcpy_locked_config(self, &val, &self->values.disable_splitlock, sizeof(long));
 	return val == 1;
 }
 

--- a/daemon/gamemode-config.h
+++ b/daemon/gamemode-config.h
@@ -107,6 +107,7 @@ float config_get_igpu_power_threshold(GameModeConfig *self);
 void config_get_soft_realtime(GameModeConfig *self, char softrealtime[CONFIG_VALUE_MAX]);
 long config_get_renice_value(GameModeConfig *self);
 long config_get_ioprio_value(GameModeConfig *self);
+bool config_get_disable_splitlock(GameModeConfig *self);
 
 /*
  * Get various config info for gpu optimisations

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -226,12 +226,13 @@ static int game_mode_disable_splitlock(GameModeContext *self, bool disable)
 		}
 
 		if (fgets(value_str, sizeof value_str, f) == NULL) {
-			LOG_ERROR("Couldn't read from /proc/sys/kernel/split_lock_mitigate : %s\n", strerror(errno));
+			LOG_ERROR("Couldn't read from /proc/sys/kernel/split_lock_mitigate : %s\n",
+				  strerror(errno));
 			fclose(f);
 			return 1;
 		}
 
-		self->initial_split_lock_mitigate = strtol (value_str, NULL, 10);
+		self->initial_split_lock_mitigate = strtol(value_str, NULL, 10);
 		fclose(f);
 
 		value_num = 0;
@@ -426,7 +427,7 @@ static void game_mode_context_enter(GameModeContext *self)
 		game_mode_inhibit_screensaver(true);
 
 	game_mode_disable_splitlock(self, true);
-	
+
 	/* Apply GPU optimisations by first getting the current values, and then setting the target */
 	game_mode_get_gpu(self->stored_gpu);
 	game_mode_apply_gpu(self->target_gpu);
@@ -463,7 +464,7 @@ static void game_mode_context_leave(GameModeContext *self)
 		game_mode_inhibit_screensaver(false);
 
 	game_mode_disable_splitlock(self, false);
-	
+
 	game_mode_set_governor(self, GAME_MODE_GOVERNOR_DEFAULT);
 
 	game_mode_disable_igpu_optimization(self);

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -227,7 +227,7 @@ static int game_mode_disable_splitlock(GameModeContext *self, bool disable)
 
 		if (fgets(value_str, sizeof value_str, f) == NULL) {
 			LOG_ERROR("Couldn't read from /proc/sys/kernel/split_lock_mitigate : %s\n",
-				  strerror(errno));
+		                  strerror(errno));
 			fclose(f);
 			return 1;
 		}

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -227,7 +227,7 @@ static int game_mode_disable_splitlock(GameModeContext *self, bool disable)
 
 		if (fgets(value_str, sizeof value_str, f) == NULL) {
 			LOG_ERROR("Couldn't read from /proc/sys/kernel/split_lock_mitigate : %s\n",
-		                  strerror(errno));
+			          strerror(errno));
 			fclose(f);
 			return 1;
 		}

--- a/data/polkit/actions/com.feralinteractive.GameMode.policy.in
+++ b/data/polkit/actions/com.feralinteractive.GameMode.policy.in
@@ -47,4 +47,15 @@
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 
+  <action id="com.feralinteractive.GameMode.procsys-helper">
+    <description>Modify the /proc/sys values</description>
+    <message>Authentication is required to modify the /proc/sys/ values</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>no</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@LIBEXECDIR@/procsysctl</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
 </policyconfig>

--- a/data/polkit/rules.d/gamemode.rules.in
+++ b/data/polkit/rules.d/gamemode.rules.in
@@ -5,7 +5,8 @@
 polkit.addRule(function (action, subject) {
     if ((action.id == "com.feralinteractive.GameMode.governor-helper" ||
          action.id == "com.feralinteractive.GameMode.gpu-helper" ||
-         action.id == "com.feralinteractive.GameMode.cpu-helper") &&
+         action.id == "com.feralinteractive.GameMode.cpu-helper") ||
+         action.id == "com.feralinteractive.GameMode.procsys-helper") &&
         subject.isInGroup("@GAMEMODE_PRIVILEGED_GROUP@"))
     {
         return polkit.Result.YES;

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -37,6 +37,10 @@ ioprio=0
 ; Defaults to 1
 inhibit_screensaver=1
 
+; Sets whether gamemode will disable split lock mitigation when active
+; Defaults to 1
+disable_splitlock=1
+
 [filter]
 ; If "whitelist" entry has a value(s)
 ; gamemode will reject anything not in the whitelist

--- a/util/meson.build
+++ b/util/meson.build
@@ -43,3 +43,18 @@ cpucorectl = executable(
     install: true,
     install_dir: path_libexecdir,
 )
+
+# Small target util to set values in /proc/sys/
+procsysctl_sources = [
+    'procsysctl.c',
+]
+
+procsysctl = executable(
+    'procsysctl',
+    sources: procsysctl_sources,
+    dependencies: [
+        link_daemon_common,
+    ],
+    install: true,
+    install_dir: path_libexecdir,
+)

--- a/util/procsysctl.c
+++ b/util/procsysctl.c
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2017-2023, Feral Interactive
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include "common-logging.h"
+
+static bool write_value(char *key, char *value)
+{
+	FILE *f = fopen(key, "w");
+
+	if (!f) {
+		if (errno != ENOENT)
+			LOG_ERROR("Couldn't open file at %s (%s)\n", key, strerror(errno));
+
+		return false;
+	}
+
+	if (fputs(value, f) == EOF) {
+		LOG_ERROR("Couldn't write to file at %s (%s)\n", key, strerror(errno));
+		fclose(f);
+		return false;
+	}
+
+	fclose(f);
+	return true;
+}
+
+int main(int argc, char *argv[])
+{
+	if (geteuid() != 0) {
+		LOG_ERROR("This program must be run as root\n");
+		return EXIT_FAILURE;
+	}
+
+	if (argc == 3) {
+		if (strcmp(argv[1], "split_lock_mitigate") == 0) {
+			if (!write_value("/proc/sys/kernel/split_lock_mitigate", argv[2]))
+				return EXIT_FAILURE;
+
+			return EXIT_SUCCESS;
+		} else {
+			fprintf(stderr, "unsupported key: '%s'\n", argv[1]);
+			return EXIT_FAILURE;
+		}
+	}
+
+	fprintf(stderr, "usage: procsysctl KEY VALUE\n");
+	fprintf (stderr, "where KEY can by any of 'split_lock_mitigate'\n");
+	return EXIT_FAILURE;
+}

--- a/util/procsysctl.c
+++ b/util/procsysctl.c
@@ -69,6 +69,6 @@ int main(int argc, char *argv[])
 	}
 
 	fprintf(stderr, "usage: procsysctl KEY VALUE\n");
-	fprintf (stderr, "where KEY can by any of 'split_lock_mitigate'\n");
+	fprintf(stderr, "where KEY can by any of 'split_lock_mitigate'\n");
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
With this patch the user can disable the split lock mitigation in the Linux kernel that otherwise can create quite sever performance penalities in some Windows games (e.g God of War).

Closes #425