### PR TITLE
Fix hybrid CPU core pinning

### DIFF
--- a/daemon/gamemode-cpu.c
+++ b/daemon/gamemode-cpu.c
@@ -134,7 +134,7 @@ static int walk_sysfs(char *cpulist, char **buf, size_t *buflen, GameModeCPUInfo
 						max_freq = freq;
 					}
 
-					if (freq - cutoff >= max_freq)
+					if (freq + cutoff >= max_freq)
 						CPU_SET_S((size_t)cpu, CPU_ALLOC_SIZE(info->num_cpu), freq_cores);
 				}
 			}


### PR DESCRIPTION
Previously the condition would always evaluate to `false`. With the fix any core with >=95% of `max_freq` will be added to the set of cores to keep.

I tested this on my system with a 13600k by comparing the results of running a `make -j20` job with and without gamemode. With gamemode I saw the expected results, namely:

- only the first 12 cores showing significant usage with the rest being close to 0%.
- `taskset -ap $PID` returning `fff` for the `make` process, instead of the default `fffff`.

Fixes #451.