### PR TITLE
Fixed crash if dbus is not accesible

### DIFF
--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -150,7 +150,7 @@ static int log_error(const char *fmt, ...)
 
 static void hop_off_the_bus(DBusConnection **bus)
 {
-	if (bus == NULL)
+	if (bus == NULL || *bus == NULL)
 		return;
 
 	dbus_connection_unref(*bus);


### PR DESCRIPTION
When running an application without dbus connection I get the following crash:
```
GameMode ERROR: Could not connect to bus: Failed to connect to socket /run/firejail/mnt/dbus/user: Permission denied
dbus[5]: arguments to dbus_connection_unref() were incorrect, assertion "connection != NULL" failed in file ../../../dbus/dbus-connection.c line 2832.
This is normally a bug in some application using the D-Bus library.

  D-Bus not built with -rdynamic so unable to print a backtrace
```
I'm well aware that gamemode will not run without dbus but for the calling `real_gamemode_query_status`  function I would expect the function to just return the fact that it's not accessible( by returning -1) and not just close the app if failed.
