### PR TITLE
use posix basename to fix build on musl

### DIFF
--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <ini.h>
 
 #include <dirent.h>
+#include <libgen.h>
 #include <math.h>
 #include <pthread.h>
 #include <pwd.h>


### PR DESCRIPTION
Fixes an issue where the build failed with musl and gcc 13.2

glibc provides a nonstandard basename implementation, this can be overriden and posix basename can be used by including libgen.h, however musl only has posix basename, and must always include libgen.h

In this particular case, it doesn't appear that using the posix version of basename will cause any issues, as it is simply being used to match a hardcoded config file name.

This is probably safe, since musl has been always been using posix basename without issues, but some further testing with glibc might be needed