### PR TITLE
Fix idle inhibitor closing bus connection too early

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,6 @@ AlwaysBreakTemplateDeclarations: false
 BinPackArguments: false
 BinPackParameters: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -87,6 +87,8 @@ struct GameModeContext {
 
 	struct GameModeCPUInfo *cpu; /**<Stored CPU info for the current CPU */
 
+	GameModeIdleInhibitor *idle_inhibitor;
+
 	bool igpu_optimization_enabled;
 	uint32_t last_cpu_energy_uj;
 	uint32_t last_igpu_energy_uj;
@@ -423,8 +425,10 @@ static void game_mode_context_enter(GameModeContext *self)
 	}
 
 	/* Inhibit the screensaver */
-	if (config_get_inhibit_screensaver(self->config))
-		game_mode_inhibit_screensaver(true);
+	if (config_get_inhibit_screensaver(self->config)) {
+		game_mode_destroy_idle_inhibitor(self->idle_inhibitor);
+		self->idle_inhibitor = game_mode_create_idle_inhibitor();
+	}
 
 	game_mode_disable_splitlock(self, true);
 
@@ -460,8 +464,10 @@ static void game_mode_context_leave(GameModeContext *self)
 	game_mode_unpark_cpu(self->cpu);
 
 	/* UnInhibit the screensaver */
-	if (config_get_inhibit_screensaver(self->config))
-		game_mode_inhibit_screensaver(false);
+	if (config_get_inhibit_screensaver(self->config)) {
+		game_mode_destroy_idle_inhibitor(self->idle_inhibitor);
+		self->idle_inhibitor = NULL;
+	}
 
 	game_mode_disable_splitlock(self, false);
 

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -219,7 +219,9 @@ void game_mode_undo_core_pinning(const GameModeCPUInfo *info, const pid_t client
 /** gamemode-dbus.c
  * Provides an API interface for using dbus
  */
+typedef struct GameModeIdleInhibitor GameModeIdleInhibitor;
 void game_mode_context_loop(GameModeContext *context) __attribute__((noreturn));
-int game_mode_inhibit_screensaver(bool inhibit);
+GameModeIdleInhibitor *game_mode_create_idle_inhibitor(void);
+void game_mode_destroy_idle_inhibitor(GameModeIdleInhibitor *inhibitor);
 void game_mode_client_registered(pid_t);
 void game_mode_client_unregistered(pid_t);


### PR DESCRIPTION
According to the [Idle Inhibition Service specification](https://specifications.freedesktop.org/idle-inhibit-spec/latest/ch03.html), inhibition stops when the client disconnects from the bus:
> Inhibition will stop when the `UnInhibit` method is called, or the application disconnects from the D-Bus session bus (which usually happens upon exit).