### PR TITLE
Add homepage url to metainfo

### DIFF
--- a/data/io.github.feralinteractive.gamemode.metainfo.xml
+++ b/data/io.github.feralinteractive.gamemode.metainfo.xml
@@ -36,4 +36,6 @@
     <category>Utility</category>
     <category>Game</category>
   </categories>
+
+  <url type="homepage">https://feralinteractive.github.io/gamemode</url>
 </component>


### PR DESCRIPTION
This fixes the "validate metainfo test" when building with appstream 1.0.2:

```
==================================== 2/2 =====================================
test:         validate metainfo file
start time:   02:26:39
duration:     0.03s
result:       exit status 3
command:      ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MALLOC_PERTURB_=54 /nix/store/820k815yafj6c7b3iqa2nl9qqs520ypc-appstream-1.0.2/bin/appstreamcli validate --no-net --pedantic /build/source/build/../data/io.github.feralinteractive.gamemode.metainfo.xml
----------------------------------- stdout -----------------------------------
I: io.github.feralinteractive.gamemode:6: summary-first-word-not-capitalized
I: io.github.feralinteractive.gamemode:7: developer-name-tag-deprecated
W: io.github.feralinteractive.gamemode:~: url-homepage-missing
I: io.github.feralinteractive.gamemode:~: developer-info-missing

✘ Validation failed: warnings: 1, infos: 3
==============================================================================
```

Fixes #468.