### PR TITLE
fix project version in meson.build (1.8.1->1.8.2)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'gamemode',
     'c',
     default_options : ['c_std=c11', 'warning_level=3'],
-    version: '1.8.1',
+    version: '1.8.2',
     license: 'BSD',
 )
 


### PR DESCRIPTION
Hi, here's a minor one-line fix. When building from source I was puzzled why `bootstrap.sh` was showing 1.8.1 when I intended to install 1.8.2.