### PR TITLE
Increase NVIDIA overclock limit

### DIFF
--- a/daemon/gamemode-gpu.c
+++ b/daemon/gamemode-gpu.c
@@ -100,8 +100,8 @@ int game_mode_initialise_gpu(GameModeConfig *config, GameModeGPUInfo **info)
 		/* Reject values over some guessed values
 		 * If a user wants to go into very unsafe levels they can recompile
 		 */
-		const int nv_core_hard_limit = 200;
-		const int nv_mem_hard_limit = 2000;
+		const int nv_core_hard_limit = 300;
+		const int nv_mem_hard_limit = 3000;
 		if (new_info->nv_core > nv_core_hard_limit || new_info->nv_mem > nv_mem_hard_limit) {
 			LOG_ERROR(
 			    "NVIDIA Overclock value above safety levels of +%d (core) +%d (mem), will "


### PR DESCRIPTION
Personally I'm against this hand-holding (you already require root permissions to overclock at all) and think that the whole block of code gotta go but if you wanna keep this at least use some more realistic numbers. I can personally do 140/2790 (150 clock crashes, 2800 vram has artifacts) but I've seen people comfortably at 250 clock so 300 should be a good upper bound.
I would also suggest that instead of failing at all to just do a `max(config_get_nv_core_clock_mhz_offset(), 300)` but that would require a few more changes.