### PR TITLE
Support setting the platform profile

### DIFF
--- a/common/common-profile.c
+++ b/common/common-profile.c
@@ -1,0 +1,78 @@
+/*
+
+Copyright (c) 2025, MithicSpirit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#define _GNU_SOURCE
+
+#include "common-profile.h"
+#include "common-logging.h"
+
+/**
+ * Path for platform profile
+ */
+const char *profile_path = "/sys/firmware/acpi/platform_profile";
+
+/**
+ * Return the current platform profile state
+ */
+const char *get_profile_state(void)
+{
+	/* Persistent profile state */
+	static char profile[64] = { 0 };
+	memset(profile, 0, sizeof(profile));
+
+	FILE *f = fopen(profile_path, "r");
+	if (!f) {
+		LOG_ERROR("Failed to open file for read %s\n", profile_path);
+		return "none";
+	}
+
+	/* Grab the file length */
+	fseek(f, 0, SEEK_END);
+	long length = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	if (length == -1) {
+		LOG_ERROR("Failed to seek file %s\n", profile_path);
+	} else {
+		char contents[length + 1];
+
+		if (fread(contents, 1, (size_t)length, f) > 0) {
+			strtok(contents, "\n");
+			strncpy(profile, contents, sizeof(profile) - 1);
+		} else {
+			LOG_ERROR("Failed to read contents of %s\n", profile_path);
+		}
+	}
+
+	fclose(f);
+
+	return profile;
+}

--- a/common/common-profile.h
+++ b/common/common-profile.h
@@ -1,0 +1,44 @@
+/*
+
+Copyright (c) 2025, MithicSpirit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#pragma once
+
+#include <linux/limits.h>
+
+/**
+ * Path for platform profile
+ */
+extern const char *profile_path;
+
+/**
+ * Get the current platform profile state
+ */
+const char *get_profile_state(void);

--- a/common/common-profile.h
+++ b/common/common-profile.h
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2025, MithicSpirit
+Copyright (c) 2025, the GameMode contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/common/common-splitlock.h
+++ b/common/common-splitlock.h
@@ -29,50 +29,16 @@ POSSIBILITY OF SUCH DAMAGE.
 
  */
 
-#define _GNU_SOURCE
+#pragma once
 
-#include "common-profile.h"
-#include "common-logging.h"
-
-/**
- * Path for platform profile
- */
-const char *profile_path = "/sys/firmware/acpi/platform_profile";
+#include <linux/limits.h>
 
 /**
- * Return the current platform profile state
+ * Path for the split lock mitagation state
  */
-const char *get_profile_state(void)
-{
-	/* Persistent profile state */
-	static char profile[64] = { 0 };
-	memset(profile, 0, sizeof(profile));
+extern const char *splitlock_path;
 
-	FILE *f = fopen(profile_path, "r");
-	if (!f) {
-		LOG_ERROR("Failed to open file for read %s\n", profile_path);
-		return "none";
-	}
-
-	/* Grab the file length */
-	fseek(f, 0, SEEK_END);
-	long length = ftell(f);
-	fseek(f, 0, SEEK_SET);
-
-	if (length == -1) {
-		LOG_ERROR("Failed to seek file %s\n", profile_path);
-	} else {
-		char contents[length + 1];
-
-		if (fread(contents, 1, (size_t)length, f) > 0) {
-			strtok(contents, "\n");
-			strncpy(profile, contents, sizeof(profile) - 1);
-		} else {
-			LOG_ERROR("Failed to read contents of %s\n", profile_path);
-		}
-	}
-
-	fclose(f);
-
-	return profile;
-}
+/**
+ * Get the current split lock mitigation state
+ */
+long get_splitlock_state(void);

--- a/common/meson.build
+++ b/common/meson.build
@@ -2,6 +2,7 @@
 common_sources = [
     'common-logging.c',
     'common-governors.c',
+    'common-profile.c',
     'common-external.c',
     'common-helpers.c',
     'common-gpu.c',

--- a/common/meson.build
+++ b/common/meson.build
@@ -3,6 +3,7 @@ common_sources = [
     'common-logging.c',
     'common-governors.c',
     'common-profile.c',
+    'common-splitlock.c',
     'common-external.c',
     'common-helpers.c',
     'common-gpu.c',

--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -88,6 +88,9 @@ struct GameModeConfig {
 		char defaultgov[CONFIG_VALUE_MAX];
 		char desiredgov[CONFIG_VALUE_MAX];
 
+		char defaultprof[CONFIG_VALUE_MAX];
+		char desiredprof[CONFIG_VALUE_MAX];
+
 		char igpu_desiredgov[CONFIG_VALUE_MAX];
 		float igpu_power_threshold;
 
@@ -265,6 +268,10 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			valid = get_string_value(value, self->values.defaultgov);
 		} else if (strcmp(name, "desiredgov") == 0) {
 			valid = get_string_value(value, self->values.desiredgov);
+		} else if (strcmp(name, "defaultprof") == 0) {
+			valid = get_string_value(value, self->values.defaultprof);
+		} else if (strcmp(name, "desiredprof") == 0) {
+			valid = get_string_value(value, self->values.desiredprof);
 		} else if (strcmp(name, "igpu_desiredgov") == 0) {
 			valid = get_string_value(value, self->values.igpu_desiredgov);
 		} else if (strcmp(name, "igpu_power_threshold") == 0) {
@@ -691,11 +698,27 @@ void config_get_default_governor(GameModeConfig *self, char governor[CONFIG_VALU
 }
 
 /*
- * Get the chosen desired governor
+ * Get the chosen desired platform profile
  */
 void config_get_desired_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX])
 {
 	memcpy_locked_config(self, governor, self->values.desiredgov, sizeof(self->values.desiredgov));
+}
+
+/*
+ * Get the chosen default platform profile
+ */
+void config_get_default_profile(GameModeConfig *self, char profile[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self, profile, self->values.defaultprof, sizeof(self->values.defaultprof));
+}
+
+/*
+ * Get the chosen desired governor
+ */
+void config_get_desired_profile(GameModeConfig *self, char profile[CONFIG_VALUE_MAX])
+{
+	memcpy_locked_config(self, profile, self->values.desiredprof, sizeof(self->values.desiredprof));
 }
 
 /*

--- a/daemon/gamemode-config.h
+++ b/daemon/gamemode-config.h
@@ -102,6 +102,8 @@ bool config_get_inhibit_screensaver(GameModeConfig *self);
 long config_get_script_timeout(GameModeConfig *self);
 void config_get_default_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);
 void config_get_desired_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);
+void config_get_default_profile(GameModeConfig *self, char profile[CONFIG_VALUE_MAX]);
+void config_get_desired_profile(GameModeConfig *self, char profile[CONFIG_VALUE_MAX]);
 void config_get_igpu_desired_governor(GameModeConfig *self, char governor[CONFIG_VALUE_MAX]);
 float config_get_igpu_power_threshold(GameModeConfig *self);
 void config_get_soft_realtime(GameModeConfig *self, char softrealtime[CONFIG_VALUE_MAX]);

--- a/data/polkit/actions/com.feralinteractive.GameMode.policy.in
+++ b/data/polkit/actions/com.feralinteractive.GameMode.policy.in
@@ -58,4 +58,16 @@
     <annotate key="org.freedesktop.policykit.exec.path">@LIBEXECDIR@/procsysctl</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
+
+  <action id="com.feralinteractive.GameMode.profile-helper">
+    <description>Modify the platform profile</description>
+    <message>Authentication is required to modify platform profile</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>no</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@LIBEXECDIR@/platprofctl</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
 </policyconfig>

--- a/data/polkit/rules.d/gamemode.rules.in
+++ b/data/polkit/rules.d/gamemode.rules.in
@@ -6,7 +6,8 @@ polkit.addRule(function (action, subject) {
     if ((action.id == "com.feralinteractive.GameMode.governor-helper" ||
          action.id == "com.feralinteractive.GameMode.gpu-helper" ||
          action.id == "com.feralinteractive.GameMode.cpu-helper" ||
-         action.id == "com.feralinteractive.GameMode.procsys-helper") &&
+         action.id == "com.feralinteractive.GameMode.procsys-helper" ||
+         action.id == "com.feralinteractive.GameMode.profile-helper") &&
         subject.isInGroup("@GAMEMODE_PRIVILEGED_GROUP@"))
     {
         return polkit.Result.YES;

--- a/example/gamemode.ini
+++ b/example/gamemode.ini
@@ -7,6 +7,11 @@ desiredgov=performance
 ; The default governor is used when leaving GameMode instead of restoring the original value
 ;defaultgov=powersave
 
+; The desired platform profile is used when entering GameMode instead of "performance"
+desiredprof=performance
+; The default platform profile is used when leaving GameMode instead of restoring the original value
+;defaultgov=low-power
+
 ; The iGPU desired governor is used when the integrated GPU is under heavy load
 igpu_desiredgov=powersave
 ; Threshold to use to decide when the integrated GPU is under heavy load.

--- a/util/meson.build
+++ b/util/meson.build
@@ -58,3 +58,18 @@ procsysctl = executable(
     install: true,
     install_dir: path_libexecdir,
 )
+
+# Small target util to get and set platform profile
+platprofctl_sources = [
+    'platprofctl.c',
+]
+
+platprofctl = executable(
+    'platprofctl',
+    sources: platprofctl_sources,
+    dependencies: [
+        link_daemon_common,
+    ],
+    install: true,
+    install_dir: path_libexecdir,
+)

--- a/util/platprofctl.c
+++ b/util/platprofctl.c
@@ -1,0 +1,84 @@
+/*
+
+Copyright (c) 2025, MithicSpirit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Feral Interactive nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#define _GNU_SOURCE
+
+#include "common-logging.h"
+#include "common-profile.h"
+
+#include <unistd.h>
+
+/**
+ * Sets platform profile to a value
+ */
+static int set_profile_state(const char *value)
+{
+	int retval = EXIT_SUCCESS;
+
+	FILE *f = fopen(profile_path, "w");
+	if (!f) {
+		LOG_ERROR("Failed to open file for write %s\n", profile_path);
+		retval = EXIT_FAILURE;
+	}
+
+	if (fprintf(f, "%s\n", value) < 0) {
+		LOG_ERROR("Failed to set platform profile to %s: %s", value, strerror(errno));
+		retval = EXIT_FAILURE;
+	}
+	fclose(f);
+
+	return retval;
+}
+
+/**
+ * Main entry point, dispatch to the appropriate helper
+ */
+int main(int argc, char *argv[])
+{
+	if (argc == 2 && strncmp(argv[1], "get", 3) == 0) {
+		printf("%s", get_profile_state());
+	} else if (argc == 3 && strncmp(argv[1], "set", 3) == 0) {
+		const char *value = argv[2];
+
+		/* Must be root to set the state */
+		if (geteuid() != 0) {
+			LOG_ERROR("This program must be run as root\n");
+			return EXIT_FAILURE;
+		}
+
+		return set_profile_state(value);
+	} else {
+		fprintf(stderr, "usage: platprofctl [get] [set VALUE]\n");
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/util/platprofctl.c
+++ b/util/platprofctl.c
@@ -1,6 +1,6 @@
 /*
 
-Copyright (c) 2025, MithicSpirit
+Copyright (c) 2025, the GameMode contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/util/procsysctl.c
+++ b/util/procsysctl.c
@@ -27,8 +27,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #define _GNU_SOURCE
 #include <unistd.h>
 #include "common-logging.h"
+#include "common-splitlock.h"
 
-static bool write_value(char *key, char *value)
+static bool write_value(const char *key, const char *value)
 {
 	FILE *f = fopen(key, "w");
 
@@ -58,7 +59,7 @@ int main(int argc, char *argv[])
 
 	if (argc == 3) {
 		if (strcmp(argv[1], "split_lock_mitigate") == 0) {
-			if (!write_value("/proc/sys/kernel/split_lock_mitigate", argv[2]))
+			if (!write_value(splitlock_path, argv[2]))
 				return EXIT_FAILURE;
 
 			return EXIT_SUCCESS;


### PR DESCRIPTION
See commit messages for more details.

This adds support for setting the platform profile via `/sys/firmware/acpi/platform_profile`. It behaves very similarly to the governor, but with just one file.

Note that setting the platform profile may change other options (like the governor) and prevent them from being altered further. Thus, this also necessitates a small refactor where the initial values are stored before any changes.

The tests for platform profile treat it as required (set the status to `-1` if they fail). However, I'm not sure whether this should be the case, as I don't know how common this feature is yet.

My nitpicking also got the best of me, so I extracted split lock mitigation stuff into `common-splitlock.c`. For now, this really only matters for the path, but, in theory, `procsysctl` could be altered to also allow getting the split lock mitigation state, rather than just setting it. Please let me know if this change is undesired, as I can just remove the last commit if so.

Closes #516