### PR TITLE
add RestartGamemode command

### DIFF
--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -134,6 +134,26 @@ static int method_query_status(sd_bus_message *m, void *userdata,
 }
 
 /**
+ * Handles the RestartGamemode D-BUS Method
+ */
+static int method_restart_gamemode(sd_bus_message *m, void *userdata,
+                                   __attribute__((unused)) sd_bus_error *ret_error)
+{
+	int pid = 0;
+	GameModeContext *context = userdata;
+
+	int ret = sd_bus_message_read(m, "i", &pid);
+	if (ret < 0) {
+		LOG_ERROR("Failed to parse input parameters: %s\n", strerror(-ret));
+		return ret;
+	}
+
+	int status = game_mode_context_restart(context, (pid_t)pid, (pid_t)pid);
+
+	return sd_bus_reply_method_return(m, "i", status);
+}
+
+/**
  * Handles the RegisterGameByPID D-BUS Method
  */
 static int method_register_game_by_pid(sd_bus_message *m, void *userdata,
@@ -402,6 +422,7 @@ static const sd_bus_vtable gamemode_vtable[] = {
 	SD_BUS_METHOD("RegisterGame", "i", "i", method_register_game, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("UnregisterGame", "i", "i", method_unregister_game, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("QueryStatus", "i", "i", method_query_status, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("RestartGamemode", "i", "i", method_restart_gamemode, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("RegisterGameByPID", "ii", "i", method_register_game_by_pid,
 	              SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("UnregisterGameByPID", "ii", "i", method_unregister_game_by_pid,

--- a/daemon/gamemode.h
+++ b/daemon/gamemode.h
@@ -156,6 +156,16 @@ int game_mode_context_unregister(GameModeContext *self, pid_t pid, pid_t request
 int game_mode_context_query_status(GameModeContext *self, pid_t pid, pid_t requester);
 
 /**
+ * Restart gamemode if it is running
+ *
+ * @param pid Process ID for the remote client
+ * @returns 0 if gamemode was restarted
+ *          1 if gamemode was already deactivated
+ *          -2 if this request was rejected
+ */
+int game_mode_context_restart(GameModeContext *self, pid_t pid, pid_t requester);
+
+/**
  * Query the config of a gamemode context
  *
  * @param context A gamemode context

--- a/lib/client_impl.c
+++ b/lib/client_impl.c
@@ -379,6 +379,12 @@ extern int real_gamemode_query_status(void)
 {
 	return gamemode_request("QueryStatus", 0);
 }
+//
+// Wrapper to call RestartGamemode
+extern int real_gamemode_request_restart(void)
+{
+	return gamemode_request("RestartGamemode", 0);
+}
 
 // Wrapper to call RegisterGameByPID
 extern int real_gamemode_request_start_for(pid_t pid)

--- a/lib/gamemode_client.h
+++ b/lib/gamemode_client.h
@@ -103,6 +103,7 @@ typedef int (*api_call_pid_return_int)(pid_t);
 static api_call_return_int REAL_internal_gamemode_request_start = NULL;
 static api_call_return_int REAL_internal_gamemode_request_end = NULL;
 static api_call_return_int REAL_internal_gamemode_query_status = NULL;
+static api_call_return_int REAL_internal_gamemode_request_restart = NULL;
 static api_call_return_cstring REAL_internal_gamemode_error_string = NULL;
 static api_call_pid_return_int REAL_internal_gamemode_request_start_for = NULL;
 static api_call_pid_return_int REAL_internal_gamemode_request_end_for = NULL;
@@ -165,6 +166,10 @@ __attribute__((always_inline)) static inline int internal_load_libgamemode(void)
 		{ "real_gamemode_query_status",
 		  (void **)&REAL_internal_gamemode_query_status,
 		  sizeof(REAL_internal_gamemode_query_status),
+		  false },
+		{ "real_gamemode_request_restart",
+		  (void **)&REAL_internal_gamemode_request_restart,
+		  sizeof(REAL_internal_gamemode_request_restart),
 		  false },
 		{ "real_gamemode_error_string",
 		  (void **)&REAL_internal_gamemode_error_string,
@@ -317,6 +322,24 @@ __attribute__((always_inline)) static inline int gamemode_query_status(void)
 	}
 
 	return REAL_internal_gamemode_query_status();
+}
+
+/* Redirect to the real libgamemode */
+__attribute__((always_inline)) static inline int gamemode_request_restart(void)
+{
+	/* Need to load gamemode */
+	if (internal_load_libgamemode() < 0) {
+		return -1;
+	}
+
+	if (REAL_internal_gamemode_request_restart == NULL) {
+		snprintf(internal_gamemode_client_error_string,
+		         sizeof(internal_gamemode_client_error_string),
+		         "gamemode_request_restart missing (older host?)");
+		return -1;
+	}
+
+	return REAL_internal_gamemode_request_restart();
 }
 
 /* Redirect to the real libgamemode */


### PR DESCRIPTION
This command allows GameMode to leave the context and then enter it again, which
re-applies all system optimizations. It is useful in cases where another
program (like TLP) may override GameMode's optimizations.

This is exposed to users by the `-R` or `--restart` flags to `gamemoded`.
