### PR TITLE
Prevent platform profile error on unsupported systems

### DIFF
--- a/common/common-profile.c
+++ b/common/common-profile.c
@@ -40,6 +40,14 @@ POSSIBILITY OF SUCH DAMAGE.
 const char *profile_path = "/sys/firmware/acpi/platform_profile";
 
 /**
+ * Check if platform profile file exists
+ */
+int profile_exists(void)
+{
+	return !access(profile_path, F_OK);
+}
+
+/**
  * Return the current platform profile state
  */
 const char *get_profile_state(void)

--- a/common/common-profile.h
+++ b/common/common-profile.h
@@ -32,11 +32,17 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <linux/limits.h>
+#include <unistd.h>
 
 /**
  * Path for platform profile
  */
 extern const char *profile_path;
+
+/**
+ * Check if platform profile file exists
+ */
+int profile_exists(void);
 
 /**
  * Get the current platform profile state

--- a/daemon/gamemode-context.c
+++ b/daemon/gamemode-context.c
@@ -317,7 +317,7 @@ static int game_mode_set_governor(GameModeContext *self, enum GameModeGovernor g
 
 static void game_mode_store_profile(GameModeContext *self)
 {
-	if (self->current_profile != GAME_MODE_PROFILE_DEFAULT)
+	if (!profile_exists() || self->current_profile != GAME_MODE_PROFILE_DEFAULT)
 		return;
 
 	const char *initial_state = get_profile_state();
@@ -332,6 +332,11 @@ static void game_mode_store_profile(GameModeContext *self)
 static int game_mode_set_profile(GameModeContext *self, enum GameModeProfile prof)
 {
 	if (self->current_profile == prof) {
+		return 0;
+	}
+
+	if (!profile_exists()) {
+		LOG_MSG("Setting platform profile unsupported; skipping\n");
 		return 0;
 	}
 

--- a/daemon/gamemode-tests.c
+++ b/daemon/gamemode-tests.c
@@ -361,6 +361,9 @@ static int run_cpu_governor_tests(struct GameModeConfig *config)
 /* Check the platform profile setting works */
 static int run_platform_profile_tests(struct GameModeConfig *config)
 {
+	if (!profile_exists())
+		return 1;
+
 	/* get the two config parameters we care about */
 	char desiredprof[CONFIG_VALUE_MAX] = { 0 };
 	config_get_desired_profile(config, desiredprof);
@@ -866,15 +869,17 @@ static int game_mode_run_feature_tests(struct GameModeConfig *config)
 	{
 		LOG_MSG("::: Verifying platform profile setting\n");
 
-		int govstatus = run_platform_profile_tests(config);
+		int profstatus = run_platform_profile_tests(config);
 
-		if (govstatus == 0)
+		if (profstatus == 1)
+			LOG_MSG("::: Passed (platform profile not supported)\n");
+		else if (profstatus == 0)
 			LOG_MSG("::: Passed\n");
 		else {
 			LOG_MSG("::: Failed!\n");
 			LOG_MSG("    -- You may need to add your user to the gamemode group:");
 			LOG_MSG("    -- $ sudo usermod -aG gamemode $(whoami)");
-			// Consider the platform profile feature requried
+			// If available, setting the platform profile should work
 			status = -1;
 		}
 	}


### PR DESCRIPTION
If a system does not support setting the platform profile (i.e., does
not have the file `/sys/firmware/acpi/platform_profile`), then everything
that interacts with it is skipped to prevent errors.

Closes #524
