### PR TITLE
fix static analyzer error that is blocking CI

### DIFF
--- a/util/platprofctl.c
+++ b/util/platprofctl.c
@@ -46,7 +46,7 @@ static int set_profile_state(const char *value)
 	FILE *f = fopen(profile_path, "w");
 	if (!f) {
 		LOG_ERROR("Failed to open file for write %s\n", profile_path);
-		retval = EXIT_FAILURE;
+		return EXIT_FAILURE;
 	}
 
 	if (fprintf(f, "%s\n", value) < 0) {


### PR DESCRIPTION
This fixes the problem that clang-18 finds. Clang-20 on newer distros generates some false positives in other places that I do not know how to disable.