### PR TITLE
data/gamemode*: switch to using posix shell

### DIFF
--- a/data/gamemodelist
+++ b/data/gamemodelist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Created by Sam Gleske
 # Created Sat Jan  1 16:56:54 EST 2022
 # MIT License - https://github.com/samrocketman/home

--- a/data/gamemoderun
+++ b/data/gamemoderun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Helper script to launch games with gamemode
 
 GAMEMODEAUTO_NAME="libgamemodeauto.so.0"


### PR DESCRIPTION
This PR changes `gamemodelist` and `gamemoderun` to use the POSIX shell, since those scripts don't depend on any bashism.

This is also helpful for downstream package maintainers, since `gamemode` will no longer depend on `bash`.