### PR TITLE
gpu: Fix NVIDIA GPU index detection when card0 is missing

### DIFF
--- a/util/gpuclockctl.c
+++ b/util/gpuclockctl.c
@@ -131,8 +131,10 @@ static long get_gpu_index_id_nv(struct GameModeGPUInfo *info)
 	}
 
 	if (nv_device < 0) {
-		LOG_ERROR("Could not resolve NVIDIA index for DRM card%ld (no NVIDIA cards found up to that index)\n",
-		          info->device);
+		LOG_ERROR(
+		    "Could not resolve NVIDIA index for DRM card%ld (no NVIDIA cards found up to that "
+		    "index)\n",
+		    info->device);
 	}
 
 	return nv_device;


### PR DESCRIPTION
On systems without /sys/class/drm/card0, gamemode fails to detect the correct NVIDIA GPU index when the GPU device is explicitly set in gamemode.ini.

This patch adjusts get_gpu_index_id_nv() to skip over non-NVIDIA devices without prematurely failing, correctly mapping the configured DRM device index to the NVML index.

Fixes: #486
Tested on: RTX 5060 ti (driver 575.64.03) on Ubuntu 25.04, cards 0-2 and some other random numbers were tested