### PR TITLE
Remove unreachable code and duplicate the noreturn label

### DIFF
--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -658,7 +658,7 @@ static const sd_bus_vtable game_vtable[] = {
 /**
  * Main process loop for the daemon. Run until quitting has been requested.
  */
-void game_mode_context_loop(GameModeContext *context)
+__attribute__((noreturn)) void game_mode_context_loop(GameModeContext *context)
 {
 	/* Set up function to handle clean up of resources */
 	atexit(clean_up);

--- a/daemon/gamemoded.c
+++ b/daemon/gamemoded.c
@@ -353,9 +353,5 @@ int main(int argc, char *argv[])
 	/* Run the main dbus message loop */
 	game_mode_context_loop(context);
 
-	game_mode_context_destroy(context);
-
-	/* Log we're finished */
-	LOG_MSG("Quitting naturally...\n");
-	sd_notify(0, "STATUS=GameMode is quitting naturally...\n");
+	/* The contex loop is noreturn, exit is handled elsewhere */
 }


### PR DESCRIPTION
Spotted when having a look at the main function - `game_mode_context_loop` is noreturn and is attributed as such at it's declaration. This duplicates that attribute over to the definition and removes redundant code.

Turns out GameMode could never "quit naturally", at least not since the dbus loop was implemented. 

