### PR TITLE
Actually ignore GPU options from protected locations

### DIFF
--- a/daemon/gamemode-config.c
+++ b/daemon/gamemode-config.c
@@ -315,6 +315,7 @@ static int inih_handler(void *user, const char *section, const char *name, const
 			    "will be ignored!\n",
 			    name);
 			LOG_ERROR("Consider moving this option to /etc/gamemode.ini\n");
+			return 1;
 		}
 
 		/* GPU subsection */


### PR DESCRIPTION
This seems to have been a mistake from back in https://github.com/FeralInteractive/gamemode/pull/103

As can be seen in that review the code only logs and does not actually do any real work to act on the caution