### PR TITLE
Correct types of the /Games path properties

### DIFF
--- a/daemon/gamemode-dbus.c
+++ b/daemon/gamemode-dbus.c
@@ -644,13 +644,13 @@ static int game_object_get_timestamp(sd_bus *local_bus, const char *path, const 
 static const sd_bus_vtable game_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("ProcessId", "i", game_object_get_process_id, 0,
-	                SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	                SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Executable", "s", game_object_get_executable, 0,
-	                SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	                SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Requester", "i", game_object_get_requester, 0,
-	                SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	                SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Timestamp", "t", game_object_get_timestamp, 0,
-	                SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	                SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_VTABLE_END
 };
 /* clang-format on */


### PR DESCRIPTION
No code calls `sd_bus_emit_properties_changed` for these, and they're constant anyway in the current code, so the types here should probably be corrected